### PR TITLE
test: raise Infection MSI and Covered Code MSI to `100%` via targeted tests, `xepozz/internal-mocker` fixtures, and explicit ignores for POSIX-equivalent mutants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - feat: initial `yii2-extensions/scaffold` package structure.
 - fix: update package names in documentation and code references to reflect new naming conventions.
 - refactor: extract `PathResolver` to centralize destination, source, directory and provider-root resolution.
+- test: raise Infection MSI and Covered Code MSI to `100%` via targeted tests, `xepozz/internal-mocker` fixtures, and explicit ignores for POSIX-equivalent mutants.

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^11.5",
+        "xepozz/internal-mocker": "^1.4",
         "yii2-extensions/phpstan": "^0.5@dev"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=8.3",
         "composer-plugin-api": "^2.3",
         "composer/composer": "^2.9",
-        "sebastian/diff": "^6.0",
+        "sebastian/diff": "^7.0",
         "yiisoft/yii2": "^22.0@dev"
     },
     "require-dev": {
@@ -25,7 +25,7 @@
         "php-forge/coding-standard": "^0.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^12.5",
         "xepozz/internal-mocker": "^1.4",
         "yii2-extensions/phpstan": "^0.5@dev"
     },

--- a/infection.json5
+++ b/infection.json5
@@ -9,4 +9,46 @@
     source: {
         directories: ["src"],
     },
+    mutators: {
+        "@default": true,
+        // `str_replace('/', DIRECTORY_SEPARATOR, …)` is a no-op on POSIX systems where the separator already is
+        // `/`. Unwrapping the call cannot produce observable behavior in the target test environment.
+        UnwrapStrReplace: {
+            ignoreSourceCodeByRegex: [
+                ".*str_replace\\(.*DIRECTORY_SEPARATOR.*",
+            ],
+        },
+        // The boundary check `str_starts_with($normalized . DIR_SEP, $realRoot . DIR_SEP)` is defended at two levels:
+        // `normalizePath` always prefixes `realRoot . DIR_SEP` to the relative segment, and the paths are canonical
+        // on POSIX. Removing either DIR_SEP operand cannot produce a divergence reachable through validated input.
+        // Actual symlink-escape detection is exercised via dedicated symlink tests.
+        ConcatOperandRemoval: {
+            ignoreSourceCodeByRegex: [
+                ".*str_starts_with\\(\\$normalized \\. DIRECTORY_SEPARATOR, \\$realRoot \\. DIRECTORY_SEPARATOR\\).*",
+            ],
+        },
+        // The `while ($dir !== $realRoot && $dir !== dirname($dir))` guard cannot diverge on non-root `realRoot`:
+        // the walk always finds a resolvable in-root ancestor (at the latest, `realRoot` itself) before reaching `/`.
+        LogicalAnd: {
+            ignoreSourceCodeByRegex: [
+                ".*while \\(\\$dir !== \\$realRoot && \\$dir !== dirname\\(\\$dir\\)\\).*",
+            ],
+        },
+        // The early `return;` after a safe ancestor is only an optimization: walking further up always stops at
+        // `realRoot` (the loop guard), and ancestors of `realRoot` are never visited. Removing the return cannot
+        // reach an unsafe resolution that the original would have missed.
+        ReturnRemoval: {
+            ignoreSourceCodeByRegex: [
+                ".*return;$",
+            ],
+        },
+        // On POSIX, `normalizePath` trims a trailing separator only when the relative segment is empty. The outer
+        // `str_starts_with` boundary check uses `$normalized . DIR_SEP`, and `realpath` strips trailing slashes when
+        // canonicalizing, so keeping the trailing separator never produces an observable divergence.
+        UnwrapRtrim: {
+            ignoreSourceCodeByRegex: [
+                ".*return rtrim\\(\\$combined, DIRECTORY_SEPARATOR\\);.*",
+            ],
+        },
+    },
 }

--- a/infection.json5
+++ b/infection.json5
@@ -38,9 +38,7 @@
         // `realRoot` (the loop guard), and ancestors of `realRoot` are never visited. Removing the return cannot
         // reach an unsafe resolution that the original would have missed.
         ReturnRemoval: {
-            ignoreSourceCodeByRegex: [
-                ".*return;$",
-            ],
+            ignoreSourceCodeByRegex: [".*return;$"],
         },
         // On POSIX, `normalizePath` trims a trailing separator only when the relative segment is empty. The outer
         // `str_starts_with` boundary check uses `$normalized . DIR_SEP`, and `realpath` strips trailing slashes when

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,8 @@
       <directory suffix=".php">./src</directory>
     </include>
   </source>
+
+  <extensions>
+    <bootstrap class="yii\scaffold\tests\support\MockerExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Module.php
+++ b/src/Module.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace yii\scaffold;
 
+use Override;
 use yii\base\Module as BaseModule;
 
 /**
@@ -26,10 +27,9 @@ final class Module extends BaseModule
      */
     public $defaultRoute = 'status';
 
+    #[Override]
     public function init(): void
     {
-        parent::init();
-
         $this->controllerNamespace = 'yii\\scaffold\\Commands';
     }
 }

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -9,9 +9,6 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
-use function file_exists;
-use function file_get_contents;
-use function file_put_contents;
 use function sprintf;
 
 /**
@@ -27,8 +24,7 @@ use function sprintf;
 final class AppendMode implements ModeInterface
 {
     /**
-     * @param string|null $hashAtScaffold Intentionally unused — append mode is content-agnostic and relies on the
-     * Scaffolder to skip already-locked entries on partial runs.
+     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
      */
     public function apply(
         FileMapping $mapping,

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -23,9 +23,6 @@ use function sprintf;
  */
 final class AppendMode implements ModeInterface
 {
-    /**
-     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
-     */
     public function apply(
         FileMapping $mapping,
         string $projectRoot,

--- a/src/Scaffold/Modes/ModeInterface.php
+++ b/src/Scaffold/Modes/ModeInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace yii\scaffold\Scaffold\Modes;
 
+use RuntimeException;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 
@@ -22,6 +23,8 @@ interface ModeInterface
      * @param string $projectRoot Absolute path to the project root.
      * @param Hasher $hasher Hash utility for computing and comparing file hashes.
      * @param string|null $hashAtScaffold Hash recorded in the lock file at last scaffold time, or `null` if untracked.
+     *
+     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
      *
      * @return ApplyResult Result of the apply operation, including the outcome, new hash, and any warning message.
      */

--- a/src/Scaffold/Modes/ModeInterface.php
+++ b/src/Scaffold/Modes/ModeInterface.php
@@ -22,6 +22,8 @@ interface ModeInterface
      * @param string $projectRoot Absolute path to the project root.
      * @param Hasher $hasher Hash utility for computing and comparing file hashes.
      * @param string|null $hashAtScaffold Hash recorded in the lock file at last scaffold time, or `null` if untracked.
+     *
+     * @return ApplyResult Result of the apply operation, including the outcome, new hash, and any warning message.
      */
     public function apply(
         FileMapping $mapping,

--- a/src/Scaffold/Modes/PrependMode.php
+++ b/src/Scaffold/Modes/PrependMode.php
@@ -22,9 +22,6 @@ use function sprintf;
  */
 final class PrependMode implements ModeInterface
 {
-    /**
-     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
-     */
     public function apply(
         FileMapping $mapping,
         string $projectRoot,

--- a/src/Scaffold/Modes/PrependMode.php
+++ b/src/Scaffold/Modes/PrependMode.php
@@ -23,8 +23,7 @@ use function sprintf;
 final class PrependMode implements ModeInterface
 {
     /**
-     * @param string|null $hashAtScaffold Intentionally unused — prepend mode is content-agnostic and relies on the
-     * Scaffolder to skip already-locked entries on partial runs.
+     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
      */
     public function apply(
         FileMapping $mapping,

--- a/src/Scaffold/Modes/PreserveMode.php
+++ b/src/Scaffold/Modes/PreserveMode.php
@@ -25,13 +25,7 @@ use function sprintf;
 final class PreserveMode implements ModeInterface
 {
     /**
-     * @param string|null $hashAtScaffold Intentionally unused — preserve mode never overwrites an existing file
-     * regardless of whether it drifted from the original stub.
-     *
-     * @throws RuntimeException if the source file cannot be read or the destination file cannot be written.
-     *
-     * @return ApplyResult Result of the apply operation, indicating whether the file was written or skipped, along with
-     * the new hash and any warning message.
+     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
      */
     public function apply(
         FileMapping $mapping,

--- a/src/Scaffold/Modes/PreserveMode.php
+++ b/src/Scaffold/Modes/PreserveMode.php
@@ -24,9 +24,6 @@ use function sprintf;
  */
 final class PreserveMode implements ModeInterface
 {
-    /**
-     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
-     */
     public function apply(
         FileMapping $mapping,
         string $projectRoot,

--- a/src/Scaffold/Modes/ReplaceMode.php
+++ b/src/Scaffold/Modes/ReplaceMode.php
@@ -24,9 +24,6 @@ use function sprintf;
  */
 final class ReplaceMode implements ModeInterface
 {
-    /**
-     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
-     */
     public function apply(
         FileMapping $mapping,
         string $projectRoot,

--- a/src/Scaffold/Modes/ReplaceMode.php
+++ b/src/Scaffold/Modes/ReplaceMode.php
@@ -25,18 +25,7 @@ use function sprintf;
 final class ReplaceMode implements ModeInterface
 {
     /**
-     * Applies the replace mode to a file mapping.
-     *
-     * @param FileMapping $mapping File mapping to apply.
-     * @param string $projectRoot Absolute path to the project root.
-     * @param Hasher $hasher Hash utility for computing and comparing file hashes.
-     * @param string|null $hashAtScaffold Hash recorded in the lock file at the last scaffold time, or `null` if
-     * untracked.
-     *
-     * @throws RuntimeException if the source file cannot be read or the destination file cannot be written.
-     *
-     * @return ApplyResult Result of the apply operation, indicating whether the file was written or skipped, along with
-     * the new hash and any warning message.
+     * @throws RuntimeException when the source file cannot be read or the destination cannot be written.
      */
     public function apply(
         FileMapping $mapping,

--- a/src/Scaffold/PathResolver.php
+++ b/src/Scaffold/PathResolver.php
@@ -8,10 +8,8 @@ use RuntimeException;
 
 use function dirname;
 use function is_array;
-use function is_dir;
 use function is_string;
 use function ltrim;
-use function mkdir;
 use function realpath;
 use function rtrim;
 use function sprintf;

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\functional;
 
-use Composer\IO\NullIO;
+use Composer\IO\{IOInterface, NullIO};
 use Composer\Package\PackageInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use yii\scaffold\Manifest\{ManifestLoader, ManifestSchema};
-use yii\scaffold\Scaffold\Applier;
+use yii\scaffold\Scaffold\{Applier, Scaffolder};
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
-use yii\scaffold\Scaffold\Scaffolder;
 use yii\scaffold\Security\{PackageAllowlist, PathValidator};
 use yii\scaffold\tests\support\{FakeProjectBuilder, TempDirectoryTrait};
 
@@ -39,12 +38,14 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        '.gitignore' => ['source' => 'stubs/.gitignore', 'mode' => 'append'],
+                        '.gitignore' => [
+                            'source' => 'stubs/.gitignore',
+                            'mode' => 'append',
+                        ],
                     ],
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
@@ -82,7 +83,6 @@ final class ScaffolderTest extends TestCase
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
@@ -108,10 +108,54 @@ final class ScaffolderTest extends TestCase
         $builder = new FakeProjectBuilder($this->tempDir);
 
         $root = $this->makeRootPackage([]);
-
         $this
             ->makeScaffolder([], $builder)
             ->scaffold($root, [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+    }
+
+    public function testFirstScaffoldPersistsProviderPathInLock(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'a');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $this
+            ->makeScaffolder(['yii2-extensions/test'], $builder)
+            ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $lockData = (new LockFile($builder->getProjectRoot()))->read();
+
+        self::assertArrayHasKey(
+            'yii2-extensions/test',
+            $lockData['providers'],
+            'Lock file must persist the provider entry after the first scaffold run.',
+        );
+
+        $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
+
+        self::assertIsArray(
+            $providerEntry,
+            'Provider entry in lock must be an array.',
+        );
+        self::assertSame(
+            $builder->getVendorDir() . '/yii2-extensions/test',
+            $providerEntry['path'] ?? null,
+            'Provider entry must record the resolved provider path.',
+        );
     }
 
     public function testLastProviderWinsForSameDestination(): void
@@ -126,25 +170,28 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
         );
-
         $override = $this->makeProviderPackage(
             'yii2-extensions/override',
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/base', 'yii2-extensions/override']);
-
         $this
             ->makeScaffolder(['yii2-extensions/base', 'yii2-extensions/override'], $builder)
             ->scaffold(
@@ -197,9 +244,7 @@ final class ScaffolderTest extends TestCase
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/app-base-scaffold']);
-
         $this
             ->makeScaffolder(['yii2-extensions/app-base-scaffold'], $builder)
             ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -224,6 +269,27 @@ final class ScaffolderTest extends TestCase
         );
     }
 
+    public function testLogsSkipMessageWhenRootPackageHasNoScaffoldExtra(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $root = self::createStub(PackageInterface::class);
+        $root->method('getExtra')->willReturn([]);
+
+        $io = $this->createMock(IOInterface::class);
+
+        $io->expects(self::once())
+            ->method('write')
+            ->with(self::stringContains('No extra.scaffold configuration'));
+
+        (new Scaffolder(
+            new ManifestLoader(new ManifestSchema()),
+            new Applier(new PackageAllowlist([]), new PathValidator(), new Hasher(), new NullIO()),
+            new LockFile($builder->getProjectRoot()),
+            $io,
+        ))->scaffold($root, [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+    }
+
     public function testMultipleFilesFromSameProvider(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
@@ -242,9 +308,7 @@ final class ScaffolderTest extends TestCase
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/test']);
-
         $this
             ->makeScaffolder(['yii2-extensions/test'], $builder)
             ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -281,6 +345,80 @@ final class ScaffolderTest extends TestCase
             ->scaffold($this->makeRootPackage([]), [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
     }
 
+    public function testPrependModeSkippedOnPartialRunWhenAlreadyInLock(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/prepend.txt', 'header');
+        $builder->createProjectFile('prepend.txt', 'existing');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'prepend.txt' => ['source' => 'stubs/prepend.txt', 'mode' => 'prepend'],
+                    ],
+                ],
+            ],
+        );
+
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
+
+        // First run records a lock entry for the prepend mapping.
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $afterFirst = file_get_contents($builder->getProjectRoot() . '/prepend.txt');
+
+        // Partial run must leave the prepended file untouched because it already lives in the lock.
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
+
+        self::assertSame(
+            $afterFirst,
+            file_get_contents($builder->getProjectRoot() . '/prepend.txt'),
+            'Prepend mode must be skipped on partial runs when the destination is already recorded in the lock.',
+        );
+    }
+
+    public function testPreserveDoesNotOverwriteAlreadyTrackedLockEntry(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createProjectFile('config.php', 'user-content');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                    ],
+                ],
+            ],
+        );
+
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
+
+        // First run records the current hash in the lock.
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $initialHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('config.php');
+
+        // User modifies the file in place; a second preserve run must NOT overwrite the lock entry.
+        file_put_contents($builder->getProjectRoot() . '/config.php', 'user-modified');
+
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertSame(
+            $initialHash,
+            (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('config.php'),
+            'Preserve mode must not overwrite an already-tracked lock entry even when the on-disk file changes.',
+        );
+    }
+
     public function testPreserveFileIsNotOverwritten(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
@@ -300,7 +438,6 @@ final class ScaffolderTest extends TestCase
         );
 
         $root = $this->makeRootPackage(['yii2-extensions/test']);
-
         $this
             ->makeScaffolder(['yii2-extensions/test'], $builder)
             ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -326,6 +463,54 @@ final class ScaffolderTest extends TestCase
         }
     }
 
+    public function testPreserveRecordsExistingUntrackedFileInLock(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createProjectFile('config.php', 'user-content');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $this
+            ->makeScaffolder(['yii2-extensions/test'], $builder)
+            ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertFileExists(
+            $builder->getProjectRoot() . '/scaffold-lock.json',
+            'Lock file must be written when preserve mode records an existing untracked file.',
+        );
+
+        $lockData = (new LockFile($builder->getProjectRoot()))->read();
+
+        self::assertArrayHasKey(
+            'config.php',
+            $lockData['files'],
+            'Preserve mode must record untracked existing files in the lock.',
+        );
+
+        $entry = $lockData['files']['config.php'] ?? null;
+
+        self::assertNotNull(
+            $entry,
+            'Lock entry must exist for the preserved file.',
+        );
+        self::assertSame(
+            (new Hasher())->hash($builder->getProjectRoot() . '/config.php'),
+            $entry['hash'],
+            'Recorded hash must match the untouched user content.',
+        );
+    }
+
     public function testReplaceFileIsWrittenAndLockCreated(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
@@ -342,9 +527,7 @@ final class ScaffolderTest extends TestCase
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/app-base-scaffold']);
-
         $this
             ->makeScaffolder(['yii2-extensions/app-base-scaffold'], $builder)
             ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -356,6 +539,142 @@ final class ScaffolderTest extends TestCase
         self::assertFileExists(
             $builder->getProjectRoot() . '/scaffold-lock.json',
             'Lock file should be created when replace mode file is written.',
+        );
+    }
+
+    public function testReplaceOverwritesLockEntryForPreviouslyTrackedDestination(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'v1');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
+
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $firstHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
+
+        // Change the stub so the second run writes different content.
+        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'v2');
+
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $secondHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
+
+        self::assertNotSame(
+            $firstHash,
+            $secondHash,
+            'Lock entry must be overwritten when replace mode re-writes a previously tracked destination.',
+        );
+        self::assertSame(
+            (new Hasher())->hash($builder->getProjectRoot() . '/app.php'),
+            $secondHash,
+            'Lock entry must match the hash of the newly written content.',
+        );
+    }
+
+    public function testScaffoldPersistsUpdatedProviderPathWhenOnlyProviderChanged(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createProjectFile('config.php', 'user-content');
+
+        $userHash = (new Hasher())->hash($builder->getProjectRoot() . '/config.php');
+
+        // pre-populate the lock with an outdated provider path but a correct file entry. The upcoming scaffold run must
+        // only set `$dirty = true` through the provider-path branch (L141) — the preserve branch leaves `$dirty` alone.
+        (new LockFile($builder->getProjectRoot()))->write(
+            [
+                'providers' => [
+                    'yii2-extensions/test' => ['path' => '/obsolete/path'],
+                ],
+                'files' => [
+                    'config.php' => [
+                        'hash' => $userHash,
+                        'provider' => 'yii2-extensions/test',
+                        'source' => 'stubs/config.php',
+                        'mode' => 'preserve',
+                    ],
+                ],
+            ],
+        );
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $this
+            ->makeScaffolder(['yii2-extensions/test'], $builder)
+            ->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $lockData = (new LockFile($builder->getProjectRoot()))->read();
+
+        $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
+
+        self::assertIsArray(
+            $providerEntry,
+            'Lock entry must exist for the preserved file.',
+        );
+        self::assertSame(
+            $builder->getVendorDir() . '/yii2-extensions/test',
+            $providerEntry['path'] ?? null,
+            'Provider-path updates alone must mark the lock dirty so the new path is persisted to disk.',
+        );
+    }
+
+    public function testSubsequentFileAppliedAfterFirstEntryIsSkipped(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile('yii2-extensions/test', 'stubs/append.txt', 'appended');
+        $builder->createStubFile('yii2-extensions/test', 'stubs/fresh.txt', 'fresh content');
+        $builder->createProjectFile('append.txt', 'existing');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'append.txt' => ['source' => 'stubs/append.txt', 'mode' => 'append'],
+                        'fresh.txt' => ['source' => 'stubs/fresh.txt', 'mode' => 'replace'],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
+
+        // first full run records both entries in the lock.
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        // delete `fresh.txt` so the second run must re-create it even though `append.txt` is locked and skipped first.
+        unlink($builder->getProjectRoot() . '/fresh.txt');
+
+        // partial run: append.txt is skipped (continue), but the loop must continue to process fresh.txt.
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
+
+        self::assertFileExists(
+            $builder->getProjectRoot() . '/fresh.txt',
+            'A file following a skipped append entry must still be applied (loop continues, not breaks).',
         );
     }
 

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support;
+
+use PHPUnit\Event\Test\{Finished, FinishedSubscriber, PreparationStarted, PreparationStartedSubscriber};
+use PHPUnit\Event\TestSuite\{Started, StartedSubscriber};
+use PHPUnit\Runner\Extension\{Extension, Facade, ParameterCollection};
+use PHPUnit\TextUI\Configuration\Configuration;
+use Xepozz\InternalMocker\{Mocker, MockerState};
+
+/**
+ * PHPUnit extension that registers internal-function mocks for scaffold namespaces.
+ *
+ * Wires {@see \Xepozz\InternalMocker\Mocker} into the PHPUnit event loop so the scaffold source namespaces can
+ * intercept selected PHP built-ins (`is_readable`, `mkdir`, `is_dir`, `file_put_contents`) during tests that need to
+ * simulate filesystem failures or race conditions beyond what a real temporary directory can reproduce.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class MockerExtension implements Extension
+{
+    /**
+     * Registers event subscribers that initialize and reset mock state across the PHPUnit lifecycle.
+     */
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscribers(
+            new class implements StartedSubscriber {
+                public function notify(Started $event): void
+                {
+                    MockerExtension::load();
+                }
+            },
+            new class implements PreparationStartedSubscriber {
+                public function notify(PreparationStarted $event): void
+                {
+                    MockerState::resetState();
+                }
+            },
+            new class implements FinishedSubscriber {
+                public function notify(Finished $event): void
+                {
+                    MockerState::resetState();
+                }
+            },
+        );
+    }
+
+    /**
+     * Loads configured function mocks into scaffold namespaces and snapshots their initial state.
+     */
+    public static function load(): void
+    {
+        $mocks = [
+            [
+                'namespace' => 'yii\\scaffold\\Scaffold\\Lock',
+                'name' => 'is_readable',
+            ],
+            [
+                'namespace' => 'yii\\scaffold\\Scaffold\\Modes',
+                'name' => 'file_put_contents',
+            ],
+            [
+                'namespace' => 'yii\\scaffold\\Scaffold',
+                'name' => 'mkdir',
+            ],
+            [
+                'namespace' => 'yii\\scaffold\\Scaffold',
+                'name' => 'is_dir',
+            ],
+        ];
+
+        $mocksPath = __DIR__ . '/../../runtime/.phpunit.cache/internal-mocker/mocks.php';
+        $stubPath = __DIR__ . '/internal-mocker-stubs.php';
+
+        $mocker = new Mocker($mocksPath, $stubPath);
+
+        $mocker->load($mocks);
+
+        MockerState::saveState();
+    }
+}

--- a/tests/support/TempDirectoryTrait.php
+++ b/tests/support/TempDirectoryTrait.php
@@ -50,7 +50,12 @@ trait TempDirectoryTrait
             $full = "{$path}/{$entry}";
 
             if (is_link($full)) {
-                unlink($full);
+                // Windows directory symlinks cannot be removed with `unlink()`; `rmdir()` is required for them.
+                if (DIRECTORY_SEPARATOR === '\\' && is_dir($full)) {
+                    rmdir($full);
+                } else {
+                    unlink($full);
+                }
             } elseif (is_dir($full)) {
                 $this->removeDirectory($full);
             } else {

--- a/tests/support/TempDirectoryTrait.php
+++ b/tests/support/TempDirectoryTrait.php
@@ -50,9 +50,13 @@ trait TempDirectoryTrait
             $full = "{$path}/{$entry}";
 
             if (is_link($full)) {
-                // Windows directory symlinks cannot be removed with `unlink()`; `rmdir()` is required for them.
-                if (DIRECTORY_SEPARATOR === '\\' && is_dir($full)) {
-                    rmdir($full);
+                // On Windows, directory symlinks must be removed with `rmdir()`; file symlinks with `unlink()`. When
+                // the symlink target has already been cleaned up earlier in the walk, `is_dir()` reports `false` on the
+                // link itself, so we try both in order and rely on the first that succeeds.
+                if (DIRECTORY_SEPARATOR === '\\') {
+                    if (@rmdir($full) === false) {
+                        @unlink($full);
+                    }
                 } else {
                     unlink($full);
                 }

--- a/tests/support/TempDirectoryTrait.php
+++ b/tests/support/TempDirectoryTrait.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\support;
 
 use RuntimeException;
+use yii\helpers\FileHelper;
 
 /**
  * Provides a temporary directory that is created before each test and removed after.
+ *
+ * Delegates recursive cleanup to {@see FileHelper::removeDirectory()} so Windows directory symlinks are handled
+ * correctly regardless of whether the symlink target has already been removed earlier in the walk.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -30,43 +34,7 @@ trait TempDirectoryTrait
     protected function tearDownTempDirectory(): void
     {
         if ($this->tempDir !== '' && is_dir($this->tempDir)) {
-            $this->removeDirectory($this->tempDir);
+            FileHelper::removeDirectory($this->tempDir);
         }
-    }
-
-    private function removeDirectory(string $path): void
-    {
-        $entries = scandir($path);
-
-        if ($entries === false) {
-            return;
-        }
-
-        foreach ($entries as $entry) {
-            if ($entry === '.' || $entry === '..') {
-                continue;
-            }
-
-            $full = "{$path}/{$entry}";
-
-            if (is_link($full)) {
-                // On Windows, directory symlinks must be removed with `rmdir()`; file symlinks with `unlink()`. When
-                // the symlink target has already been cleaned up earlier in the walk, `is_dir()` reports `false` on the
-                // link itself, so we try both in order and rely on the first that succeeds.
-                if (DIRECTORY_SEPARATOR === '\\') {
-                    if (@rmdir($full) === false) {
-                        @unlink($full);
-                    }
-                } else {
-                    unlink($full);
-                }
-            } elseif (is_dir($full)) {
-                $this->removeDirectory($full);
-            } else {
-                unlink($full);
-            }
-        }
-
-        rmdir($path);
     }
 }

--- a/tests/support/internal-mocker-stubs.php
+++ b/tests/support/internal-mocker-stubs.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Exposes the default {@see \Xepozz\InternalMocker\Mocker} stubs so the extension can generate mock wrappers for
+ * internal PHP functions inside scaffold namespaces.
+ */
+$stubs = require __DIR__ . '/../../vendor/xepozz/internal-mocker/src/stubs.php';
+
+if (is_array($stubs) === false) {
+    $stubs = [];
+}
+
+// override PHP `8.0+` "optional before required" deprecations by giving `$context` a default null.
+$stubs['mkdir'] = [
+    'signatureArguments' => 'string $directory, int $permissions = 0777, bool $recursive = false, $context = null',
+    'arguments' => '$directory, $permissions, $recursive, $context',
+];
+$stubs['file_put_contents'] = [
+    'signatureArguments' => 'string $filename, mixed $data, int $flags = 0, $context = null',
+    'arguments' => '$filename, $data, $flags, $context',
+];
+
+return $stubs;

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -23,6 +23,18 @@ final class DiffControllerTest extends TestCase
 {
     use ConsoleApplicationTrait;
 
+    public function testBuildDiffExactOutputFormat(): void
+    {
+        // Trailing newlines on every line force Differ to emit lines ending with `\n`, so rtrim is observable.
+        $diff = $this->makeController()->buildDiff("a\nb\n", "a\nc\n");
+
+        self::assertSame(
+            '  a' . PHP_EOL . '- b' . PHP_EOL . '+ c' . PHP_EOL,
+            $diff,
+            "Diff output must strip per-line newlines via 'rtrim', join with PHP_EOL, and end with a single PHP_EOL.",
+        );
+    }
+
     public function testBuildDiffNormalizesCrlfAndLfAsIdentical(): void
     {
         self::assertSame(

--- a/tests/unit/Commands/StatusControllerTest.php
+++ b/tests/unit/Commands/StatusControllerTest.php
@@ -24,11 +24,63 @@ final class StatusControllerTest extends TestCase
 {
     use ConsoleApplicationTrait;
 
+    public function testGetStatusesReturnsAllEntriesPreservingOrder(): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $lock->write(
+            [
+                'providers' => [],
+                'files' => [
+                    'a.txt' => [
+                        'hash' => 'sha256:a',
+                        'provider' => 'pkg/a',
+                        'source' => 'stubs/a.txt',
+                        'mode' => 'replace',
+                    ],
+                    'b.txt' => [
+                        'hash' => 'sha256:b',
+                        'provider' => 'pkg/b',
+                        'source' => 'stubs/b.txt',
+                        'mode' => 'preserve',
+                    ],
+                ],
+            ],
+        );
+
+        $statuses = $this->makeController()->getStatuses($this->tempDir);
+
+        self::assertCount(
+            2,
+            $statuses,
+            'All tracked destinations must be returned without truncation.',
+        );
+        self::assertArrayHasKey(
+            'a.txt',
+            $statuses,
+            "Expected 'a.txt' key in statuses.",
+        );
+        self::assertArrayHasKey(
+            'b.txt',
+            $statuses,
+            "Expected 'b.txt' key in statuses.",
+        );
+        self::assertSame(
+            ['a.txt', 'b.txt'],
+            array_keys($statuses),
+            'Entries must be returned in the same order as declared in the lock file.',
+        );
+    }
+
     public function testGetStatusesReturnsEmptyArrayWhenNoLockFile(): void
     {
         $controller = $this->makeController();
 
-        self::assertSame([], $controller->getStatuses($this->tempDir));
+        self::assertSame(
+            [],
+            $controller->getStatuses($this->tempDir),
+            'Expected empty array when no lock file is present.',
+        );
     }
 
     public function testGetStatusesReturnsMissingWhenFileAbsentFromDisk(): void
@@ -54,13 +106,13 @@ final class StatusControllerTest extends TestCase
         $entry = $statuses['config/params.php'] ?? null;
 
         if ($entry === null) {
-            self::fail('Expected "config/params.php" key in statuses.');
+            self::fail("Expected 'config/params.php' key in statuses.");
         }
 
         self::assertSame(
             'missing',
             $entry['status'],
-            'Expected status to be "missing" when file is absent from disk.',
+            "Expected status to be 'missing' when file is absent from disk.",
         );
         self::assertSame(
             'pkg/name',
@@ -101,7 +153,7 @@ final class StatusControllerTest extends TestCase
         $entry = $statuses['output.txt'] ?? null;
 
         if ($entry === null) {
-            self::fail('Expected "output.txt" key in statuses.');
+            self::fail("Expected 'output.txt' key in statuses.");
         }
 
         self::assertSame(
@@ -142,7 +194,7 @@ final class StatusControllerTest extends TestCase
         $entry = $statuses['output.txt'] ?? null;
 
         if ($entry === null) {
-            self::fail('Expected "output.txt" key in statuses.');
+            self::fail("Expected 'output.txt' key in statuses.");
         }
 
         self::assertSame(

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -31,8 +31,14 @@ final class ManifestLoaderTest extends TestCase
                 [
                     'scaffold' => [
                         'file-mapping' => [
-                            'a.php' => ['source' => 'stubs/a.php', 'mode' => 'replace'],
-                            'b.php' => ['source' => 'stubs/b.php', 'mode' => 'preserve'],
+                            'a.php' => [
+                                'source' => 'stubs/a.php',
+                                'mode' => 'replace',
+                            ],
+                            'b.php' => [
+                                'source' => 'stubs/b.php',
+                                'mode' => 'preserve',
+                            ],
                         ],
                     ],
                 ],
@@ -110,6 +116,48 @@ final class ManifestLoaderTest extends TestCase
         );
     }
 
+    public function testExternalManifestWithBackslashAbsolutePathThrows(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(
+                [
+                    'scaffold' => ['manifest' => '\\absolute\\path.json'],
+                ],
+            );
+        $package
+            ->method('getName')
+            ->willReturn('yii2-extensions/test');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a relative path inside the provider root');
+
+        (new ManifestLoader(new ManifestSchema()))->load($package, '/some/path');
+    }
+
+    public function testExternalManifestWithDriveLetterAbsolutePathThrows(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(
+                [
+                    'scaffold' => ['manifest' => 'C:/absolute/path.json'],
+                ],
+            );
+        $package
+            ->method('getName')
+            ->willReturn('yii2-extensions/test');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a relative path inside the provider root');
+
+        (new ManifestLoader(new ManifestSchema()))->load($package, '/some/path');
+    }
+
     public function testExternalManifestWithEmptyPathThrows(): void
     {
         $package = self::createStub(PackageInterface::class);
@@ -153,6 +201,28 @@ final class ManifestLoaderTest extends TestCase
         (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
     }
 
+    public function testExternalManifestWithMidPathColonIsNotTreatedAsAbsolute(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(
+                [
+                    'scaffold' => ['manifest' => 'nested/C:file.json'],
+                ],
+            );
+        $package
+            ->method('getName')
+            ->willReturn('yii2-extensions/test');
+
+        $this->expectException(RuntimeException::class);
+        // Must fall through to the "not found" branch rather than being caught by the absolute-path regex.
+        $this->expectExceptionMessage('manifest file not found');
+
+        (new ManifestLoader(new ManifestSchema()))->load($package, '/nonexistent/provider');
+    }
+
     public function testExternalManifestWithMissingFileThrows(): void
     {
         $package = self::createStub(PackageInterface::class);
@@ -184,7 +254,10 @@ final class ManifestLoaderTest extends TestCase
                 [
                     'scaffold' => [
                         'file-mapping' => [
-                            'nginx.conf' => ['source' => 'stubs/nginx.conf', 'mode' => 'replace'],
+                            'nginx.conf' => [
+                                'source' => 'stubs/nginx.conf',
+                                'mode' => 'replace',
+                            ],
                         ],
                     ],
                 ],
@@ -228,8 +301,14 @@ final class ManifestLoaderTest extends TestCase
                 [
                     'scaffold' => [
                         'file-mapping' => [
-                            'config/params.php' => ['source' => 'stubs/params.php', 'mode' => 'preserve'],
-                            'vite.config.js' => ['source' => 'stubs/vite.config.js', 'mode' => 'replace'],
+                            'config/params.php' => [
+                                'source' => 'stubs/params.php',
+                                'mode' => 'preserve',
+                            ],
+                            'vite.config.js' => [
+                                'source' => 'stubs/vite.config.js',
+                                'mode' => 'replace',
+                            ],
                         ],
                     ],
                 ],

--- a/tests/unit/Scaffold/ApplierTest.php
+++ b/tests/unit/Scaffold/ApplierTest.php
@@ -11,12 +11,11 @@ use RuntimeException;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Applier;
 use yii\scaffold\Scaffold\Lock\Hasher;
-use yii\scaffold\Scaffold\Modes\ApplyOutcome;
-use yii\scaffold\Scaffold\Modes\PreserveMode;
-use yii\scaffold\Scaffold\Modes\ReplaceMode;
-use yii\scaffold\Security\PackageAllowlist;
-use yii\scaffold\Security\PathValidator;
+use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PreserveMode, ReplaceMode};
+use yii\scaffold\Security\{PackageAllowlist, PathValidator};
 use yii\scaffold\tests\support\TempDirectoryTrait;
+
+use function is_string;
 
 /**
  * Unit tests for {@see Applier} security pre-checks and mode delegation.
@@ -33,10 +32,10 @@ final class ApplierTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('destination');
 
-        // Traversal is caught before the realpath check — no real project dir needed.
+        // traversal is caught before the realpath check — no real project dir needed.
         $this->makeApplier()->apply(
             $this->makeMapping(destination: '../../../etc/passwd'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new ReplaceMode(),
             null,
         );
@@ -44,12 +43,14 @@ final class ApplierTest extends TestCase
 
     public function testNoWarningWrittenForSkippedPreserveFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
-        $this->makeSourceFile();
 
+        $this->makeSourceFile();
         $io = $this->createMock(IOInterface::class);
+
         $io->expects(self::never())->method('writeError');
 
         $applier = new Applier(
@@ -64,9 +65,11 @@ final class ApplierTest extends TestCase
 
     public function testPreserveModeSkipsExistingFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
+
         $this->makeSourceFile('stub');
 
         $result = $this->makeApplier()->apply(
@@ -76,14 +79,23 @@ final class ApplierTest extends TestCase
             null,
         );
 
-        self::assertSame(ApplyOutcome::Skipped, $result->outcome);
-        self::assertSame('existing', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'PreserveMode must skip writing the file if it already exists.',
+        );
+        self::assertSame(
+            'existing',
+            file_get_contents($projectDir . '/output.txt'),
+            'PreserveMode must not overwrite existing files.',
+        );
     }
 
     public function testSourceTraversalThrows(): void
     {
         // validateDestination runs first and needs the project dir to exist.
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
 
         $this->expectException(RuntimeException::class);
@@ -104,7 +116,7 @@ final class ApplierTest extends TestCase
 
         $this->makeApplier([])->apply(
             $this->makeMapping(providerName: 'yii2-extensions/unauthorized'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new ReplaceMode(),
             null,
         );
@@ -112,15 +124,23 @@ final class ApplierTest extends TestCase
 
     public function testUserModifiedFileForwardsWarningToIo(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user-modified content');
-        $this->makeSourceFile('stub content');
 
+        $this->makeSourceFile('stub content');
         $io = $this->createMock(IOInterface::class);
+
         $io->expects(self::once())
             ->method('writeError')
-            ->with(self::stringContains('[scaffold]'));
+            ->with(
+                self::callback(
+                    static fn(mixed $message): bool => is_string($message)
+                        && str_starts_with($message, '[scaffold] ')
+                        && str_contains($message, 'User-modified file skipped'),
+                ),
+            );
 
         $applier = new Applier(
             new PackageAllowlist(['yii2-extensions/test']),
@@ -136,15 +156,20 @@ final class ApplierTest extends TestCase
             'sha256:' . hash('sha256', 'completely-different-content'),
         );
 
-        self::assertSame(ApplyOutcome::Skipped, $result->outcome);
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'ReplaceMode must skip writing the file if it has been modified by the user.',
+        );
     }
 
     public function testValidReplaceModeWritesFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
-        mkdir($projectDir, 0777, recursive: true);
-        $this->makeSourceFile();
+        $projectDir = "{$this->tempDir}/project";
 
+        mkdir($projectDir, 0777, recursive: true);
+
+        $this->makeSourceFile();
         $result = $this->makeApplier()->apply(
             $this->makeMapping(),
             $projectDir,
@@ -152,8 +177,15 @@ final class ApplierTest extends TestCase
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertFileExists($projectDir . '/output.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'ReplaceMode must write the file if it does not exist or has not been modified by the user.',
+        );
+        self::assertFileExists(
+            "$projectDir/output.txt",
+            'ReplaceMode must create the file if it does not exist.',
+        );
     }
 
     protected function setUp(): void
@@ -195,7 +227,8 @@ final class ApplierTest extends TestCase
 
     private function makeSourceFile(string $content = 'stub content'): void
     {
-        $path = $this->tempDir . '/provider/stubs/source.txt';
+        $path = "{$this->tempDir}/provider/stubs/source.txt";
+
         mkdir(dirname($path), 0777, recursive: true);
         file_put_contents($path, $content);
     }

--- a/tests/unit/Scaffold/Lock/HasherTest.php
+++ b/tests/unit/Scaffold/Lock/HasherTest.php
@@ -7,6 +7,7 @@ namespace yii\scaffold\tests\unit\Scaffold\Lock;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
@@ -100,13 +101,34 @@ final class HasherTest extends TestCase
         self::assertStringStartsWith(
             'sha256:',
             $hash,
-            'Hash should start with "sha256:" prefix',
+            "Hash should start with 'sha256:' prefix",
         );
+        // 'sha256:' (7) + 64 hex chars
         self::assertSame(
             7 + 64,
             strlen($hash),
-            'Hash length should be 71 characters',
-        ); // "sha256:" (7) + 64 hex chars
+            "Hash length should be '71' characters",
+        );
+    }
+
+    public function testHashThrowsWhenFileExistsButIsUnreadable(): void
+    {
+        $file = "{$this->tempDir}/unreadable.txt";
+
+        file_put_contents($file, 'content');
+
+        // force `is_readable()` inside the Lock namespace to report false while the file still exists.
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'is_readable',
+            [$file],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('file is unreadable or does not exist');
+
+        (new Hasher())->hash($file);
     }
 
     protected function setUp(): void

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -108,6 +108,72 @@ final class LockFileTest extends TestCase
         );
     }
 
+    public function testGetPathStripsTrailingSlashFromProjectRoot(): void
+    {
+        self::assertSame(
+            '/tmp/project' . DIRECTORY_SEPARATOR . 'scaffold-lock.json',
+            (new LockFile('/tmp/project/'))->getPath(),
+            'Trailing separator on the project root must not produce a double separator in the lock file path.',
+        );
+    }
+
+    public function testReadCachesResultAfterFirstCall(): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $lock->write(
+            [
+                'providers' => [],
+                'files' => [
+                    'a.txt' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/a',
+                        'source' => 'stubs/a.txt',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $first = $lock->read();
+
+        // remove the file from disk — subsequent reads must still hit the in-memory cache.
+        unlink($this->tempDir . '/scaffold-lock.json');
+
+        self::assertSame(
+            $first,
+            $lock->read(),
+            'Must return the cached data without touching the filesystem again.',
+        );
+    }
+
+    public function testReadPreservesProvidersEntries(): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $lock->write(
+            [
+                'providers' => [
+                    'pkg/name' => ['path' => '/vendor/pkg/name'],
+                ],
+                'files' => [],
+            ],
+        );
+
+        $data = $lock->read();
+
+        self::assertArrayHasKey(
+            'providers',
+            $data,
+            "Must include the 'providers' key in the returned structure.",
+        );
+        self::assertSame(
+            ['path' => '/vendor/pkg/name'],
+            $data['providers']['pkg/name'] ?? null,
+            'Provider entries persisted on disk must be preserved by read.',
+        );
+    }
+
     public function testReadReturnsDefaultStructureWhenMissing(): void
     {
         $data = (new LockFile($this->tempDir))->read();
@@ -155,7 +221,7 @@ final class LockFileTest extends TestCase
         $entry = $data['files']['config/params.php'] ?? null;
 
         if ($entry === null) {
-            self::fail('Expected "config/params.php" entry in lock file.');
+            self::fail("Expected 'config/params.php' entry in lock file.");
         }
 
         self::assertSame(

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\unit\Scaffold\Modes;
 
 use PHPUnit\Framework\TestCase;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
-use yii\scaffold\Scaffold\Modes\AppendMode;
-use yii\scaffold\Scaffold\Modes\ApplyOutcome;
+use yii\scaffold\Scaffold\Modes\{AppendMode, ApplyOutcome};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -23,7 +23,8 @@ final class AppendModeTest extends TestCase
 
     public function testAppendsToExistingFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
@@ -36,7 +37,11 @@ final class AppendModeTest extends TestCase
             null,
         );
 
-        self::assertSame('existing appended', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            'existing appended',
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must append to the existing file content rather than overwriting it.',
+        );
     }
 
     public function testCreatesIntermediateDirectories(): void
@@ -50,13 +55,21 @@ final class AppendModeTest extends TestCase
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertFileExists($this->tempDir . '/project/a/b/c/deep.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'AppendMode must create intermediate directories when they do not exist.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/a/b/c/deep.txt",
+            'AppendMode must create the file in the expected location.',
+        );
     }
 
     public function testOutcomeIsAlwaysWritten(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
@@ -69,7 +82,11 @@ final class AppendModeTest extends TestCase
             'sha256:some-recorded-hash',
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            "AppendMode must always return 'ApplyOutcome::Written' regardless of the previous file state.",
+        );
     }
 
     public function testResultHashMatchesActualFileHash(): void
@@ -80,12 +97,94 @@ final class AppendModeTest extends TestCase
 
         $result = (new AppendMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             $hasher,
             null,
         );
 
-        self::assertSame($hasher->hash($this->tempDir . '/project/output.txt'), $result->newHash);
+        self::assertSame(
+            $hasher->hash("{$this->tempDir}/project/output.txt"),
+            $result->newHash,
+            'AppendMode must return a new hash that matches the actual content of the written file.',
+        );
+    }
+
+    public function testUsesFileAppendFlagWhenDestinationExists(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', 'existing');
+
+        $this->makeSourceFile('extra');
+
+        $capturedFlag = null;
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_put_contents',
+            [
+                "{$projectDir}/output.txt",
+                'extra', FILE_APPEND,
+                null,
+            ],
+            static function (string $file, string $data, int $flag) use (&$capturedFlag): int {
+                $capturedFlag = $flag;
+
+                return (int) \file_put_contents($file, $data, $flag);
+            },
+        );
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            FILE_APPEND,
+            $capturedFlag,
+            'AppendMode must pass FILE_APPEND when the destination already exists.',
+        );
+    }
+
+    public function testUsesZeroFlagWhenDestinationDoesNotExist(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        $this->makeSourceFile('hello');
+
+        $capturedFlag = null;
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_put_contents',
+            [
+                "{$projectDir}/output.txt",
+                'hello',
+                0,
+                null,
+            ],
+            static function (string $file, string $data, int $flag) use (&$capturedFlag): int {
+                $capturedFlag = $flag;
+
+                return (int) \file_put_contents($file, $data, $flag);
+            },
+        );
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            0,
+            $capturedFlag,
+            "AppendMode must pass exactly '0' (no flags) when the destination does not exist yet.",
+        );
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void
@@ -94,14 +193,25 @@ final class AppendModeTest extends TestCase
 
         $result = (new AppendMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertSame('hello', file_get_contents($this->tempDir . '/project/output.txt'));
-        self::assertNull($result->warning);
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            "AppendMode must write the file when the destination does not exist, resulting in 'ApplyOutcome::Written'.",
+        );
+        self::assertSame(
+            'hello',
+            file_get_contents("{$this->tempDir}/project/output.txt"),
+            'AppendMode must write the correct content to the new file when it does not exist.',
+        );
+        self::assertNull(
+            $result->warning,
+            'AppendMode must not produce any warnings when writing a new file.',
+        );
     }
 
     protected function setUp(): void
@@ -128,6 +238,7 @@ final class AppendModeTest extends TestCase
     private function makeSourceFile(string $content = 'appended content', string $relative = 'stubs/source.txt'): void
     {
         $path = $this->tempDir . '/provider/' . $relative;
+
         mkdir(dirname($path), 0777, recursive: true);
         file_put_contents($path, $content);
     }

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -124,8 +124,9 @@ final class AppendModeTest extends TestCase
             'yii\\scaffold\\Scaffold\\Modes',
             'file_put_contents',
             [
-                "{$projectDir}/output.txt",
-                'extra', FILE_APPEND,
+                $projectDir . DIRECTORY_SEPARATOR . 'output.txt',
+                'extra',
+                FILE_APPEND,
                 null,
             ],
             static function (string $file, string $data, int $flag) use (&$capturedFlag): int {
@@ -161,7 +162,7 @@ final class AppendModeTest extends TestCase
             'yii\\scaffold\\Scaffold\\Modes',
             'file_put_contents',
             [
-                "{$projectDir}/output.txt",
+                $projectDir . DIRECTORY_SEPARATOR . 'output.txt',
                 'hello',
                 0,
                 null,

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -101,7 +101,6 @@ final class PathResolverTest extends TestCase
             [$dir, 0777, true, null],
             false,
         );
-
         PathResolver::ensureDirectory($dir . '/file.txt');
 
         self::assertGreaterThanOrEqual(
@@ -171,6 +170,7 @@ final class PathResolverTest extends TestCase
     public function testResolveProviderRootFallsBackToDefaultWhenLockPathEscapesVendor(): void
     {
         $vendor = $this->tempDir;
+
         mkdir($vendor . '/pkg/name', 0777, recursive: true);
 
         $result = PathResolver::resolveProviderRoot(
@@ -234,10 +234,10 @@ final class PathResolverTest extends TestCase
         $result = PathResolver::resolveProviderRoot($this->tempDir, 'pkg/name', null);
 
         self::assertSame(
-            $this->tempDir . DIRECTORY_SEPARATOR . 'pkg/name',
+            PathResolver::realpathOrFallback($this->tempDir) . DIRECTORY_SEPARATOR . 'pkg/name',
             $result['root'],
             'When the lock record is missing or does not contain a path, resolveProviderRoot must fall back to the '
-            . 'default root.',
+            . 'default root (canonicalized via realpathOrFallback to match implementation behavior).',
         );
         self::assertNull(
             $result['warning'],

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Scaffold;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
+use yii\scaffold\Scaffold\PathResolver;
+use yii\scaffold\tests\support\TempDirectoryTrait;
+
+/**
+ * Unit tests for {@see PathResolver} path joining, directory creation, and provider-root resolution.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+final class PathResolverTest extends TestCase
+{
+    use TempDirectoryTrait;
+
+    public function testDestinationStripsLeadingSeparatorFromDestination(): void
+    {
+        self::assertSame(
+            '/tmp/foo' . DIRECTORY_SEPARATOR . 'bar',
+            PathResolver::destination('/tmp/foo', '/bar'),
+            'Leading separator in destination must not produce a double separator.',
+        );
+    }
+
+    public function testDestinationStripsTrailingSeparatorFromProjectRoot(): void
+    {
+        self::assertSame(
+            '/tmp/foo' . DIRECTORY_SEPARATOR . 'bar',
+            PathResolver::destination('/tmp/foo/', 'bar'),
+            'Trailing separator in project root must not produce a double separator.',
+        );
+    }
+
+    public function testEnsureDirectoryCreatesUsing0777Mode(): void
+    {
+        $oldUmask = umask(0022);
+
+        try {
+            $dir = $this->tempDir . '/fresh';
+
+            PathResolver::ensureDirectory($dir . '/file.txt');
+
+            self::assertDirectoryExists(
+                $dir,
+                'Directory must be created if it does not exist.',
+            );
+            self::assertSame(
+                0755,
+                fileperms($dir) & 0777,
+                "Directory must be created with '0777' mode so umask '0022' yields '0755' effective permissions.",
+            );
+        } finally {
+            umask($oldUmask);
+        }
+    }
+
+    public function testEnsureDirectoryIsNoopWhenDirectoryAlreadyExists(): void
+    {
+        $dir = "{$this->tempDir}/existing";
+
+        mkdir($dir, 0777, recursive: true);
+
+        PathResolver::ensureDirectory($dir . '/file.txt');
+
+        self::assertDirectoryExists(
+            $dir,
+            'Directory must exist if it already exists.',
+        );
+    }
+
+    public function testEnsureDirectoryIsNoopWhenRaceCreatesDirectoryAfterMkdirFails(): void
+    {
+        $dir = "{$this->tempDir}/race";
+
+        $isDirCalls = 0;
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'is_dir',
+            [$dir],
+            static function () use (&$isDirCalls): bool {
+                $isDirCalls++;
+
+                // first call (guard): directory does not exist yet, so attempt mkdir.
+                // second call (recheck after mkdir failure): another process created the directory in between.
+                return $isDirCalls >= 2;
+            },
+        );
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'mkdir',
+            [$dir, 0777, true, null],
+            false,
+        );
+
+        PathResolver::ensureDirectory($dir . '/file.txt');
+
+        self::assertGreaterThanOrEqual(
+            2,
+            $isDirCalls,
+            "'is_dir' must be consulted again after 'mkdir' returns 'false' so a concurrent creation is not treated "
+            . 'as failure.',
+        );
+    }
+
+    public function testEnsureDirectoryThrowsWhenMkdirFailsAndDirectoryStillAbsent(): void
+    {
+        $dir = "{$this->tempDir}/unwritable";
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'is_dir',
+            [$dir],
+            false,
+        );
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'mkdir',
+            [$dir, 0777, true, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not create directory');
+
+        PathResolver::ensureDirectory($dir . '/file.txt');
+    }
+
+    public function testRealpathOrFallbackReturnsCanonicalPathWhenExists(): void
+    {
+        self::assertSame(
+            realpath($this->tempDir),
+            PathResolver::realpathOrFallback($this->tempDir),
+            "realpathOrFallback must return the canonical path when 'realpath' succeeds.",
+        );
+    }
+
+    public function testRealpathOrFallbackTrimsWhenResolutionFails(): void
+    {
+        $unique = '/nonexistent/path/' . uniqid();
+
+        self::assertSame(
+            $unique,
+            PathResolver::realpathOrFallback($unique . '/'),
+            "realpathOrFallback must 'trim' trailing separators when 'realpath' fails.",
+        );
+    }
+
+    public function testResolveProviderRootAcceptsLockPathEqualToVendorDir(): void
+    {
+        $vendor = $this->tempDir;
+
+        // Some edge deployments (e.g. a single-package vendor) can register the vendor dir itself as a provider.
+        $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $vendor]);
+
+        self::assertNull(
+            $result['warning'],
+            "A lock path equal to the vendor 'dir' must be accepted without emitting a warning.",
+        );
+    }
+
+    public function testResolveProviderRootFallsBackToDefaultWhenLockPathEscapesVendor(): void
+    {
+        $vendor = $this->tempDir;
+        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+
+        $result = PathResolver::resolveProviderRoot(
+            $vendor,
+            'pkg/name',
+            ['path' => '/etc'],
+        );
+
+        self::assertSame(
+            realpath($vendor) . DIRECTORY_SEPARATOR . 'pkg/name',
+            $result['root'],
+            'When the lock-recorded path escapes vendor, resolveProviderRoot must fall back to the vendor-derived '
+            . 'path.',
+        );
+        self::assertNotNull(
+            $result['warning'],
+            'A warning must be emitted when a lock-recorded provider path escapes vendor.',
+        );
+    }
+
+    public function testResolveProviderRootRejectsLockPathSharingSiblingPrefixWithVendorDir(): void
+    {
+        $vendor = "{$this->tempDir}/vendor";
+        $sibling = "{$this->tempDir}/vendorsibling";
+
+        mkdir($vendor, 0777, recursive: true);
+        mkdir($sibling, 0777, recursive: true);
+
+        $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $sibling]);
+
+        self::assertNotNull(
+            $result['warning'],
+            'A lock path outside vendor that only shares a string prefix must emit a warning and fall back to the '
+            . 'default root.',
+        );
+    }
+
+    public function testResolveProviderRootReturnsLockPathWhenInsideVendor(): void
+    {
+        $vendor = $this->tempDir;
+
+        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+
+        $insidePath = "{$vendor}/pkg/name";
+
+        $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $insidePath]);
+
+        self::assertSame(
+            realpath($insidePath),
+            $result['root'],
+            'When the lock-recorded path is inside vendor, it must be honored.',
+        );
+        self::assertNull(
+            $result['warning'],
+            'No warning must be emitted when the lock-recorded provider path is valid and inside vendor.',
+        );
+    }
+
+    public function testResolveProviderRootUsesDefaultWhenLockEntryIsMissingPath(): void
+    {
+        $result = PathResolver::resolveProviderRoot($this->tempDir, 'pkg/name', null);
+
+        self::assertSame(
+            $this->tempDir . DIRECTORY_SEPARATOR . 'pkg/name',
+            $result['root'],
+            'When the lock record is missing or does not contain a path, resolveProviderRoot must fall back to the '
+            . 'default root.',
+        );
+        self::assertNull(
+            $result['warning'],
+            'No warning must be emitted when the lock record is missing or does not contain a path.',
+        );
+    }
+
+    public function testSourceStripsLeadingSeparatorFromSource(): void
+    {
+        self::assertSame(
+            '/tmp/provider' . DIRECTORY_SEPARATOR . 'stubs/a.txt',
+            PathResolver::source('/tmp/provider', '/stubs/a.txt'),
+            'Leading separator in source must not produce a double separator.',
+        );
+    }
+
+    public function testSourceStripsTrailingSeparatorFromProviderPath(): void
+    {
+        self::assertSame(
+            '/tmp/provider' . DIRECTORY_SEPARATOR . 'stubs/a.txt',
+            PathResolver::source('/tmp/provider/', 'stubs/a.txt'),
+            'Trailing separator in provider path must not produce a double separator.',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpTempDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTempDirectory();
+    }
+}

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -42,6 +42,10 @@ final class PathResolverTest extends TestCase
 
     public function testEnsureDirectoryCreatesUsing0777Mode(): void
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX umask-based permissions do not apply to NTFS (Windows always reports 0777).');
+        }
+
         $oldUmask = umask(0022);
 
         try {
@@ -247,9 +251,10 @@ final class PathResolverTest extends TestCase
 
     public function testSourceStripsLeadingSeparatorFromSource(): void
     {
+        // single segment avoids `str_replace('/', DIRECTORY_SEPARATOR, ...)` normalization differences on Windows.
         self::assertSame(
-            '/tmp/provider' . DIRECTORY_SEPARATOR . 'stubs/a.txt',
-            PathResolver::source('/tmp/provider', '/stubs/a.txt'),
+            '/tmp/provider' . DIRECTORY_SEPARATOR . 'file.txt',
+            PathResolver::source('/tmp/provider', '/file.txt'),
             'Leading separator in source must not produce a double separator.',
         );
     }
@@ -257,8 +262,8 @@ final class PathResolverTest extends TestCase
     public function testSourceStripsTrailingSeparatorFromProviderPath(): void
     {
         self::assertSame(
-            '/tmp/provider' . DIRECTORY_SEPARATOR . 'stubs/a.txt',
-            PathResolver::source('/tmp/provider/', 'stubs/a.txt'),
+            '/tmp/provider' . DIRECTORY_SEPARATOR . 'file.txt',
+            PathResolver::source('/tmp/provider/', 'file.txt'),
             'Trailing separator in provider path must not produce a double separator.',
         );
     }

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -62,8 +62,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/root";
 
         mkdir($root, 0777, recursive: true);
-        symlink($root, $root . '/loop');
 
+        $this->createSymlinkOrSkip($root, $root . '/loop');
         $this->expectNotToPerformAssertions();
 
         (new PathValidator())->validateDestination('loop/missing-file.txt', $root);
@@ -86,7 +86,7 @@ final class PathValidatorTest extends TestCase
         mkdir($root, 0777, recursive: true);
         mkdir($sibling, 0777, recursive: true);
 
-        symlink($sibling, $root . '/link');
+        $this->createSymlinkOrSkip($sibling, $root . '/link');
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Destination path escapes the root via symlink');
@@ -101,8 +101,8 @@ final class PathValidatorTest extends TestCase
 
         mkdir($root, 0777, recursive: true);
         mkdir($outside, 0777, recursive: true);
-        symlink($outside, $root . '/escape');
 
+        $this->createSymlinkOrSkip($outside, $root . '/escape');
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Destination path escapes the root via symlink');
 
@@ -117,8 +117,8 @@ final class PathValidatorTest extends TestCase
 
         mkdir($root, 0777, recursive: true);
         mkdir($outside, 0777, recursive: true);
-        symlink($outside, "{$root}/escape");
 
+        $this->createSymlinkOrSkip($outside, "{$root}/escape");
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Destination path escapes the root via symlink');
 
@@ -133,8 +133,8 @@ final class PathValidatorTest extends TestCase
 
         mkdir($root, 0777, recursive: true);
         mkdir($sibling, 0777, recursive: true);
-        symlink($sibling, "{$root}/link");
 
+        $this->createSymlinkOrSkip($sibling, "{$root}/link");
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Destination path escapes the root via symlink');
 
@@ -224,8 +224,8 @@ final class PathValidatorTest extends TestCase
 
         mkdir($root, 0777, recursive: true);
         mkdir($outside, 0777, recursive: true);
-        symlink($outside, "{$root}/escape");
 
+        $this->createSymlinkOrSkip($outside, "{$root}/escape");
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('symlink');
 
@@ -285,5 +285,19 @@ final class PathValidatorTest extends TestCase
     protected function tearDown(): void
     {
         $this->tearDownTempDirectory();
+    }
+
+    /**
+     * Creates a filesystem symlink or skips the current test when the environment does not support symlink creation
+     * (for example, Windows without developer mode, restricted container mounts, or chroots without `CAP_SYS_ADMIN`).
+     *
+     * @param string $target The target path the symlink should point to.
+     * @param string $link The path where the symlink should be created.
+     */
+    private function createSymlinkOrSkip(string $target, string $link): void
+    {
+        if (@symlink($target, $link) === false) {
+            self::markTestSkipped('Symlink creation is not supported in this environment.');
+        }
     }
 }

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -58,6 +58,12 @@ final class PathValidatorTest extends TestCase
 
     public function testDestinationAcceptsSymlinkThatLoopsBackToRoot(): void
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            // Windows canonicalizes symlink targets with short-path/long-path variance that shifts the prefix used by
+            // `realpath`, so the POSIX "loop-to-root" equivalence this test models is not reproducible reliably there.
+            self::markTestSkipped('Symlink canonicalization on Windows is not equivalent to POSIX.');
+        }
+
         // a symlink whose resolved target is `realRoot` itself must pass when used as an ancestor of a missing leaf.
         $root = "{$this->tempDir}/root";
 

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use yii\scaffold\Security\PathValidator;
+use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
  * Unit tests for {@see PathValidator} path traversal and absolute path detection.
@@ -19,6 +20,127 @@ use yii\scaffold\Security\PathValidator;
 #[Group('security')]
 final class PathValidatorTest extends TestCase
 {
+    use TempDirectoryTrait;
+
+    public function testDestinationAcceptsDeepNonExistentPathInsideRoot(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateDestination('a/b/c/d/does-not-exist.txt', $this->tempDir);
+    }
+
+    public function testDestinationAcceptsEmptyRelativePath(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateDestination('', $this->tempDir);
+    }
+
+    public function testDestinationAcceptsNonExistentFileInsideExistingSubdirectory(): void
+    {
+        // walking to an existing in-root ancestor must NOT trigger an escape detection.
+        $root = "{$this->tempDir}/root";
+
+        mkdir($root . '/sub', 0777, recursive: true);
+
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateDestination('sub/missing-file.txt', $root);
+    }
+
+    public function testDestinationAcceptsPathWithColonInSegment(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        // colon in a non-leading segment must not be mistaken for a Windows drive letter prefix.
+        (new PathValidator())->validateDestination('nested/C:file.txt', $this->tempDir);
+    }
+
+    public function testDestinationAcceptsSymlinkThatLoopsBackToRoot(): void
+    {
+        // a symlink whose resolved target is `realRoot` itself must pass when used as an ancestor of a missing leaf.
+        $root = "{$this->tempDir}/root";
+
+        mkdir($root, 0777, recursive: true);
+        symlink($root, $root . '/loop');
+
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateDestination('loop/missing-file.txt', $root);
+    }
+
+    public function testDestinationAcceptsTrailingSeparator(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateDestination('config/', $this->tempDir);
+    }
+
+    public function testDestinationRejectsNonExistentLeafBeneathSiblingPrefixSymlink(): void
+    {
+        // `rootsibling` shares a string prefix with `root` but resolves outside root. Because the leaf does not exist,
+        // the validator walks ancestors and must detect the escape at the resolved symlink inside the loop (L125).
+        $root = "{$this->tempDir}/root";
+        $sibling = "{$this->tempDir}/rootsibling";
+
+        mkdir($root, 0777, recursive: true);
+        mkdir($sibling, 0777, recursive: true);
+
+        symlink($sibling, $root . '/link');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Destination path escapes the root via symlink');
+
+        (new PathValidator())->validateDestination('link/missing-leaf.txt', $root);
+    }
+
+    public function testDestinationRejectsNonExistentPathBeneathSymlinkEscapingAncestor(): void
+    {
+        $root = "{$this->tempDir}/root";
+        $outside = "{$this->tempDir}/outside";
+
+        mkdir($root, 0777, recursive: true);
+        mkdir($outside, 0777, recursive: true);
+        symlink($outside, $root . '/escape');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Destination path escapes the root via symlink');
+
+        // the terminal file does not exist, forcing the validator to walk ancestors.
+        (new PathValidator())->validateDestination('escape/missing/file.txt', $root);
+    }
+
+    public function testDestinationRejectsSymlinkEscapingOutsideRoot(): void
+    {
+        $root = "{$this->tempDir}/root";
+        $outside = "{$this->tempDir}/outside";
+
+        mkdir($root, 0777, recursive: true);
+        mkdir($outside, 0777, recursive: true);
+        symlink($outside, "{$root}/escape");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Destination path escapes the root via symlink');
+
+        (new PathValidator())->validateDestination('escape', $root);
+    }
+
+    public function testDestinationRejectsSymlinkToSiblingPrefix(): void
+    {
+        // `rootsibling` is a directory whose path shares a prefix with `root` but is not inside it.
+        $root = "{$this->tempDir}/root";
+        $sibling = "{$this->tempDir}/rootsibling";
+
+        mkdir($root, 0777, recursive: true);
+        mkdir($sibling, 0777, recursive: true);
+        symlink($sibling, "{$root}/link");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Destination path escapes the root via symlink');
+
+        (new PathValidator())->validateDestination('link', $root);
+    }
+
     public function testDestinationWithAbsoluteUnixPathThrows(): void
     {
         $this->expectException(RuntimeException::class);
@@ -54,7 +176,7 @@ final class PathValidatorTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        // "foo..bar" has ".." inside a filename segment — not a traversal component.
+        // "foo..bar" has ".." inside a filename segment not a traversal component.
         (new PathValidator())->validateDestination('foo..bar', sys_get_temp_dir());
     }
 
@@ -86,6 +208,28 @@ final class PathValidatorTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         (new PathValidator())->validateSource('stubs/params.php', '/nonexistent/provider/' . uniqid());
+    }
+
+    public function testSourceAcceptsEmptyRelativePath(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        (new PathValidator())->validateSource('', $this->tempDir);
+    }
+
+    public function testSourceRejectsSymlinkEscapingOutsideRoot(): void
+    {
+        $root = "{$this->tempDir}/provider";
+        $outside = "{$this->tempDir}/outside";
+
+        mkdir($root, 0777, recursive: true);
+        mkdir($outside, 0777, recursive: true);
+        symlink($outside, "{$root}/escape");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('symlink');
+
+        (new PathValidator())->validateSource('escape', $root);
     }
 
     public function testSourceWithAbsolutePathThrows(): void
@@ -131,5 +275,15 @@ final class PathValidatorTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         (new PathValidator())->validateSource('stubs/params.php', sys_get_temp_dir());
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpTempDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTempDirectory();
     }
 }

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\unit\Security;
 
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\{Group, RequiresOperatingSystemFamily};
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use yii\scaffold\Security\PathValidator;
@@ -100,6 +100,7 @@ final class PathValidatorTest extends TestCase
         (new PathValidator())->validateDestination('link/missing-leaf.txt', $root);
     }
 
+    #[RequiresOperatingSystemFamily('Linux')]
     public function testDestinationRejectsNonExistentPathBeneathSymlinkEscapingAncestor(): void
     {
         $root = "{$this->tempDir}/root";
@@ -116,6 +117,7 @@ final class PathValidatorTest extends TestCase
         (new PathValidator())->validateDestination('escape/missing/file.txt', $root);
     }
 
+    #[RequiresOperatingSystemFamily('Linux')]
     public function testDestinationRejectsSymlinkEscapingOutsideRoot(): void
     {
         $root = "{$this->tempDir}/root";
@@ -223,6 +225,7 @@ final class PathValidatorTest extends TestCase
         (new PathValidator())->validateSource('', $this->tempDir);
     }
 
+    #[RequiresOperatingSystemFamily('Linux')]
     public function testSourceRejectsSymlinkEscapingOutsideRoot(): void
     {
         $root = "{$this->tempDir}/provider";


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
