### PR TITLE
feat: record `providers[name]` in `scaffold-lock.json` as `{version, path}` with project-root-relative paths so committed locks stay stable across machines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - fix: update package names in documentation and code references to reflect new naming conventions.
 - refactor: extract `PathResolver` to centralize destination, source, directory and provider-root resolution.
 - test: raise Infection MSI and Covered Code MSI to `100%` via targeted tests, `xepozz/internal-mocker` fixtures, and explicit ignores for POSIX-equivalent mutants.
+- feat: record `providers[name]` in `scaffold-lock.json` as `{version, path}` with project-root-relative paths so committed locks stay stable across machines.

--- a/src/Commands/DiffController.php
+++ b/src/Commands/DiffController.php
@@ -58,6 +58,7 @@ final class DiffController extends Controller
             Yii::$app->vendorPath,
             $entry['provider'],
             $data['providers'][$entry['provider']] ?? null,
+            $projectRoot,
         );
 
         $providerRoot = $resolved['root'];

--- a/src/Commands/ReapplyController.php
+++ b/src/Commands/ReapplyController.php
@@ -81,6 +81,7 @@ final class ReapplyController extends Controller
                 $vendorDir,
                 $entry['provider'],
                 $data['providers'][$entry['provider']] ?? null,
+                $projectRoot,
             );
 
             $providerRoot = $resolved['root'];

--- a/src/Scaffold/PathResolver.php
+++ b/src/Scaffold/PathResolver.php
@@ -10,6 +10,7 @@ use function dirname;
 use function is_array;
 use function is_string;
 use function ltrim;
+use function preg_match;
 use function realpath;
 use function rtrim;
 use function sprintf;
@@ -73,15 +74,24 @@ final class PathResolver
      * Resolves the absolute root of a provider package, honoring the lock-recorded path when it stays inside the vendor
      * directory.
      *
+     * Accepts both relative paths (resolved against `$projectRoot`) and legacy absolute paths written by earlier plugin
+     * versions.
+     *
      * @param string $vendorDir Absolute path to the Composer vendor directory.
      * @param string $providerName Provider package name (for example, `yii2-extensions/app-base`).
      * @param mixed $providerLock Decoded `providers.<name>` entry from `scaffold-lock.json`, when present.
+     * @param string $projectRoot Absolute path to the project root; required to expand relative lock paths. Pass an
+     * empty string only when the caller knows that lock-recorded paths are absolute (legacy).
      *
      * @return array{root: string, warning: string|null} An array containing the resolved provider root and an optional
      * warning message when the lock-recorded path is invalid.
      */
-    public static function resolveProviderRoot(string $vendorDir, string $providerName, mixed $providerLock): array
-    {
+    public static function resolveProviderRoot(
+        string $vendorDir,
+        string $providerName,
+        mixed $providerLock,
+        string $projectRoot = '',
+    ): array {
         $safeVendorDir = self::realpathOrFallback($vendorDir);
 
         $defaultRoot = $safeVendorDir . DIRECTORY_SEPARATOR . $providerName;
@@ -90,7 +100,16 @@ final class PathResolver
             return ['root' => $defaultRoot, 'warning' => null];
         }
 
-        $candidate = self::realpathOrFallback($providerLock['path']);
+        $recordedPath = $providerLock['path'];
+
+        $isAbsolute = str_starts_with($recordedPath, '/')
+            || str_starts_with($recordedPath, '\\')
+            || preg_match('/^[A-Za-z]:/', $recordedPath) === 1;
+        $expanded = $isAbsolute || $projectRoot === ''
+            ? $recordedPath
+            : rtrim($projectRoot, '/\\') . DIRECTORY_SEPARATOR . $recordedPath;
+
+        $candidate = self::realpathOrFallback($expanded);
 
         if (str_starts_with($candidate . DIRECTORY_SEPARATOR, $safeVendorDir . DIRECTORY_SEPARATOR)) {
             return ['root' => $candidate, 'warning' => null];

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -14,7 +14,12 @@ use yii\scaffold\Scaffold\Modes\{AppendMode, ApplyOutcome, ModeInterface, Prepen
 
 use function is_array;
 use function is_string;
+use function rtrim;
 use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
 
 /**
  * Orchestrates the full scaffold lifecycle: provider resolution, manifest loading, mode application, and lock writing.
@@ -92,7 +97,7 @@ final class Scaffolder
 
         // merge file mappings in allowed-packages order; last provider wins for duplicate destinations.
         $merged = [];
-        $resolvedProviderPaths = [];
+        $providerEntries = [];
 
         foreach ($rawAllowed as $allowedName) {
             if (!is_string($allowedName)) {
@@ -108,7 +113,10 @@ final class Scaffolder
             }
 
             $packagePath = $installPaths[$allowedName] ?? "{$vendorDir}/{$allowedName}";
-            $resolvedProviderPaths[$allowedName] = $packagePath;
+            $providerEntries[$allowedName] = [
+                'version' => $package->getPrettyVersion(),
+                'path' => self::toProjectRelative($packagePath, $projectRoot),
+            ];
 
             try {
                 $mappings = $this->loader->load($package, $packagePath);
@@ -132,12 +140,11 @@ final class Scaffolder
         $lockData = $this->lockFile->read();
         $dirty = false;
 
-        foreach ($resolvedProviderPaths as $providerName => $providerPath) {
+        foreach ($providerEntries as $providerName => $entry) {
             $existing = $lockData['providers'][$providerName] ?? null;
-            $storedPath = is_array($existing) && is_string($existing['path'] ?? null) ? $existing['path'] : null;
 
-            if ($storedPath !== $providerPath) {
-                $lockData['providers'][$providerName] = ['path' => $providerPath];
+            if (!is_array($existing) || $existing !== $entry) {
+                $lockData['providers'][$providerName] = $entry;
                 $dirty = true;
             }
         }
@@ -217,5 +224,28 @@ final class Scaffolder
     private function resolveMode(string $mode): ModeInterface
     {
         return $this->modes[$mode] ?? throw new RuntimeException(sprintf('Unknown scaffold mode "%s".', $mode));
+    }
+
+    /**
+     * Converts an absolute path to one relative to the project root, using forward slashes.
+     *
+     * Returns the input unchanged (with forward slashes) when it lies outside the project root; storing an absolute
+     * path is a safe fallback for unusual deployments where the provider lives outside the root.
+     *
+     * @param string $absolutePath Absolute path to convert.
+     * @param string $projectRoot Absolute path to the project root.
+     *
+     * @return string Relative path using forward slashes, or the normalized absolute path when outside the root.
+     */
+    private static function toProjectRelative(string $absolutePath, string $projectRoot): string
+    {
+        $normalizedRoot = rtrim(str_replace('\\', '/', $projectRoot), '/') . '/';
+        $normalizedPath = str_replace('\\', '/', $absolutePath);
+
+        if (str_starts_with($normalizedPath . '/', $normalizedRoot)) {
+            return rtrim(substr($normalizedPath, strlen($normalizedRoot)), '/');
+        }
+
+        return rtrim($normalizedPath, '/');
     }
 }

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -18,6 +18,7 @@ use function rtrim;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
+use function stripos;
 use function strlen;
 use function substr;
 
@@ -232,6 +233,9 @@ final class Scaffolder
      * Returns the input unchanged (with forward slashes) when it lies outside the project root; storing an absolute
      * path is a safe fallback for unusual deployments where the provider lives outside the root.
      *
+     * The prefix check is case-insensitive on Windows because NTFS is case-insensitive and Composer may hand back paths
+     * whose casing differs between `projectRoot` and `packagePath` (for example, `C:\Users\foo` vs. `c:\users\FOO`).
+     *
      * @param string $absolutePath Absolute path to convert.
      * @param string $projectRoot Absolute path to the project root.
      *
@@ -241,8 +245,13 @@ final class Scaffolder
     {
         $normalizedRoot = rtrim(str_replace('\\', '/', $projectRoot), '/') . '/';
         $normalizedPath = str_replace('\\', '/', $absolutePath);
+        $haystack = $normalizedPath . '/';
 
-        if (str_starts_with($normalizedPath . '/', $normalizedRoot)) {
+        $matches = DIRECTORY_SEPARATOR === '\\'
+            ? stripos($haystack, $normalizedRoot) === 0
+            : str_starts_with($haystack, $normalizedRoot);
+
+        if ($matches) {
             return rtrim(substr($normalizedPath, strlen($normalizedRoot)), '/');
         }
 

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -147,11 +147,13 @@ final class ScaffolderTest extends TestCase
 
         $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
 
+        $expectedPath = str_replace('\\', '/', $builder->getVendorDir() . '/yii2-extensions/test');
+
         self::assertSame(
-            ['version' => '2.0.0', 'path' => $builder->getVendorDir() . '/yii2-extensions/test'],
+            ['version' => '2.0.0', 'path' => $expectedPath],
             $providerEntry,
             'Provider entry must record both version and path (path stays absolute when vendor lives outside the '
-            . 'project root, as in this fixture).',
+            . 'project root, as in this fixture); separators are normalized to forward slashes.',
         );
     }
 
@@ -670,10 +672,13 @@ final class ScaffolderTest extends TestCase
 
         $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
 
+        $expectedPath = str_replace('\\', '/', $builder->getVendorDir() . '/yii2-extensions/test');
+
         self::assertSame(
-            ['version' => '2.0.0', 'path' => $builder->getVendorDir() . '/yii2-extensions/test'],
+            ['version' => '2.0.0', 'path' => $expectedPath],
             $providerEntry,
-            'Provider-entry updates alone must mark the lock dirty so the fresh {version, path} is persisted to disk.',
+            'Provider-entry updates alone must mark the lock dirty so the fresh {version, path} is persisted to disk; '
+            . 'path separators are normalized to forward slashes for cross-platform stability.',
         );
     }
 

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -147,14 +147,54 @@ final class ScaffolderTest extends TestCase
 
         $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
 
-        self::assertIsArray(
-            $providerEntry,
-            'Provider entry in lock must be an array.',
-        );
         self::assertSame(
-            $builder->getVendorDir() . '/yii2-extensions/test',
-            $providerEntry['path'] ?? null,
-            'Provider entry must record the resolved provider path.',
+            ['version' => '2.0.0', 'path' => $builder->getVendorDir() . '/yii2-extensions/test'],
+            $providerEntry,
+            'Provider entry must record both version and path (path stays absolute when vendor lives outside the '
+            . 'project root, as in this fixture).',
+        );
+    }
+
+    public function testFirstScaffoldRecordsRelativePathWhenProviderLivesInsideProject(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        // simulate the realistic layout where vendor is nested under the project root; the scaffolder must record a
+        // relative path so the committed lock stays stable across machines.
+        $providerRootInsideProject = $builder->getProjectRoot() . '/vendor/yii2-extensions/test';
+
+        mkdir($providerRootInsideProject . '/stubs', 0777, recursive: true);
+        file_put_contents($providerRootInsideProject . '/stubs/app.php', 'a');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+        $this
+            ->makeScaffolder(['yii2-extensions/test'], $builder)
+            ->scaffold(
+                $root,
+                [$provider],
+                $builder->getProjectRoot(),
+                $builder->getVendorDir(),
+                true,
+                ['yii2-extensions/test' => $providerRootInsideProject],
+            );
+
+        $lockData = (new LockFile($builder->getProjectRoot()))->read();
+
+        self::assertSame(
+            ['version' => '2.0.0', 'path' => 'vendor/yii2-extensions/test'],
+            $lockData['providers']['yii2-extensions/test'] ?? null,
+            'When the provider install path lies inside the project root, the lock must store a project-relative path '
+            . 'so the committed scaffold-lock.json stays stable across developer machines.',
         );
     }
 
@@ -630,14 +670,10 @@ final class ScaffolderTest extends TestCase
 
         $providerEntry = $lockData['providers']['yii2-extensions/test'] ?? null;
 
-        self::assertIsArray(
-            $providerEntry,
-            'Lock entry must exist for the preserved file.',
-        );
         self::assertSame(
-            $builder->getVendorDir() . '/yii2-extensions/test',
-            $providerEntry['path'] ?? null,
-            'Provider-path updates alone must mark the lock dirty so the new path is persisted to disk.',
+            ['version' => '2.0.0', 'path' => $builder->getVendorDir() . '/yii2-extensions/test'],
+            $providerEntry,
+            'Provider-entry updates alone must mark the lock dirty so the fresh {version, path} is persisted to disk.',
         );
     }
 
@@ -691,12 +727,13 @@ final class ScaffolderTest extends TestCase
     /**
      * @param array<string, mixed> $extra
      */
-    private function makeProviderPackage(string $name, array $extra): PackageInterface
+    private function makeProviderPackage(string $name, array $extra, string $version = '2.0.0'): PackageInterface
     {
         $pkg = self::createStub(PackageInterface::class);
 
         $pkg->method('getName')->willReturn($name);
         $pkg->method('getExtra')->willReturn($extra);
+        $pkg->method('getPrettyVersion')->willReturn($version);
 
         return $pkg;
     }

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -233,6 +233,31 @@ final class PathResolverTest extends TestCase
         );
     }
 
+    public function testResolveProviderRootResolvesRelativeLockPathAgainstProjectRoot(): void
+    {
+        $projectRoot = $this->tempDir;
+        $vendor = "{$projectRoot}/vendor";
+
+        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+
+        $result = PathResolver::resolveProviderRoot(
+            $vendor,
+            'pkg/name',
+            ['path' => 'vendor/pkg/name'],
+            $projectRoot,
+        );
+
+        self::assertSame(
+            realpath($vendor . '/pkg/name'),
+            $result['root'],
+            'A relative lock path must be expanded against the project root before the vendor-containment check.',
+        );
+        self::assertNull(
+            $result['warning'],
+            'No warning must be emitted when the relative path resolves inside the vendor directory.',
+        );
+    }
+
     public function testResolveProviderRootUsesDefaultWhenLockEntryIsMissingPath(): void
     {
         $result = PathResolver::resolveProviderRoot($this->tempDir, 'pkg/name', null);

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -212,27 +212,6 @@ final class PathResolverTest extends TestCase
         );
     }
 
-    public function testResolveProviderRootReturnsLockPathWhenInsideVendor(): void
-    {
-        $vendor = $this->tempDir;
-
-        mkdir($vendor . '/pkg/name', 0777, recursive: true);
-
-        $insidePath = "{$vendor}/pkg/name";
-
-        $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $insidePath]);
-
-        self::assertSame(
-            realpath($insidePath),
-            $result['root'],
-            'When the lock-recorded path is inside vendor, it must be honored.',
-        );
-        self::assertNull(
-            $result['warning'],
-            'No warning must be emitted when the lock-recorded provider path is valid and inside vendor.',
-        );
-    }
-
     public function testResolveProviderRootResolvesRelativeLockPathAgainstProjectRoot(): void
     {
         $projectRoot = $this->tempDir;
@@ -255,6 +234,27 @@ final class PathResolverTest extends TestCase
         self::assertNull(
             $result['warning'],
             'No warning must be emitted when the relative path resolves inside the vendor directory.',
+        );
+    }
+
+    public function testResolveProviderRootReturnsLockPathWhenInsideVendor(): void
+    {
+        $vendor = $this->tempDir;
+
+        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+
+        $insidePath = "{$vendor}/pkg/name";
+
+        $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $insidePath]);
+
+        self::assertSame(
+            realpath($insidePath),
+            $result['root'],
+            'When the lock-recorded path is inside vendor, it must be honored.',
+        );
+        self::assertNull(
+            $result['warning'],
+            'No warning must be emitted when the lock-recorded provider path is valid and inside vendor.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
