### PR TITLE
test: cover `eject`, `providers`, and `reapply` console commands via buffered-output spies (un-final'd for subclassing); add `docs/testing.md` and a lock-example fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - test: raise Infection MSI and Covered Code MSI to `100%` via targeted tests, `xepozz/internal-mocker` fixtures, and explicit ignores for POSIX-equivalent mutants.
 - feat: record `providers[name]` in `scaffold-lock.json` as `{version, path}` with project-root-relative paths so committed locks stay stable across machines.
 - test: add real-Composer functional tests for `post-install-cmd`, `post-create-project-cmd`, and multi-layer provider precedence.
+- test: cover `eject`, `providers`, and `reapply` console commands via buffered-output spies (un-final'd for subclassing); add `docs/testing.md` and a lock-example fix.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Register the console module in `config/console.php` to enable `yii scaffold/*` c
 - 📦 [Creating Providers](docs/providers.md)
 - 🔀 [File Modes](docs/modes.md)
 - 🖥️ [Console Commands](docs/console.md)
+- 🧪 [Testing Guide](docs/testing.md)
 
 ## Package information
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,12 @@ Example lock entry:
 
 ```json
 {
-    "providers": {},
+    "providers": {
+        "yii2-extensions/app-base": {
+            "version": "0.1.0",
+            "path": "vendor/yii2-extensions/app-base"
+        }
+    },
     "files": {
         "config/params.php": {
             "hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -70,6 +75,9 @@ Example lock entry:
     }
 }
 ```
+
+Provider paths are recorded **relative to the project root** so the lock file stays stable across developer machines.
+Versions come from Composer's `getPrettyVersion()`.
 
 ## Event differentiation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Example lock entry:
 }
 ```
 
-Provider paths are recorded **relative to the project root** so the lock file stays stable across developer machines.
+Provider paths are recorded **relative to the project root** so the lockfile stays stable across developer machines.
 Versions come from Composer's `getPrettyVersion()`.
 
 ## Event differentiation

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,131 @@
+# Testing guide
+
+This document describes how the test suite is organized, how to run specific subsets, and how to add new fixtures or
+tests when contributing.
+
+## Suite layout
+
+```
+tests/
+├── unit/                  # pure, fast unit tests per src/ namespace
+│   ├── Commands/          # console controllers via spies (no real stdout writes)
+│   ├── Manifest/
+│   ├── Modes/
+│   ├── Scaffold/
+│   │   └── Lock/
+│   └── Security/
+├── functional/            # real Composer instance, event-driven, temporary project
+├── support/               # shared helpers, spies, traits
+│   └── Spies/             # Controller subclasses that buffer stdout/stderr
+└── fixtures/              # static manifests / invalid payloads used as read-only inputs
+    └── providers/
+```
+
+The `unit` and `functional` groups are reflected in PHPUnit `#[Group]` attributes. Every test also belongs to the
+`scaffold` meta-group.
+
+## Running the suite
+
+```bash
+vendor/bin/phpunit                              # full suite, quiet
+vendor/bin/phpunit --group commands             # only console-controller tests
+vendor/bin/phpunit --group functional           # only Composer-driven end-to-end tests
+vendor/bin/phpunit --filter MultiLayer          # substring filter on test class name
+```
+
+## Unit tests
+
+Unit tests exercise a single class in isolation. Controller tests use **spies** under `tests/support/Spies/` because
+Yii's console `Controller::stdout()` writes directly to the `STDOUT` stream, which bypasses PHPUnit's output capture.
+Each spy extends its production controller and overrides `stdout()`/`stderr()` so tests can assert on buffered output.
+
+```php
+final class ProvidersControllerTest extends TestCase
+{
+    public function testExample(): void
+    {
+        $controller = new ProvidersControllerSpy('providers', $module);
+        $controller->actionIndex();
+
+        self::assertStringContainsString('pkg/name', $controller->stdoutBuffer);
+    }
+}
+```
+
+Production controllers are declared without `final` precisely to support these spies.
+
+## Functional tests
+
+Functional tests spin up a **real `Composer\Composer` instance** against a fake project generated in a temporary
+directory, seed its local repository with mock provider packages, and dispatch the same script events the plugin
+subscribes to in production. They exercise the entire chain
+
+```
+Script event → EventSubscriber → Scaffolder → modes → lock file
+```
+
+without the cost or flakiness of a full `composer install`.
+
+The `ComposerEventHarness` trait at `tests/support/ComposerEventHarness.php` centralizes the boilerplate:
+
+```php
+final class MyTest extends TestCase
+{
+    use ComposerEventHarness;
+    use TempDirectoryTrait;
+
+    public function testExample(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+        $builder->createStubFile('demo/scaffold', 'stubs/config/app.php', "<?php\n");
+        $builder->createComposerJson([
+            'name' => 'demo/smoke-project',
+            'config' => ['vendor-dir' => $builder->getVendorDir()],
+            'extra' => ['scaffold' => ['allowed-packages' => ['demo/scaffold']]],
+        ]);
+
+        $io = new BufferIO();
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->addMockProvider($composer, 'demo/scaffold', [
+            'file-mapping' => [
+                'config/app.php' => ['source' => 'stubs/config/app.php', 'mode' => 'replace'],
+            ],
+        ]);
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
+
+        self::assertFileExists($builder->getProjectRoot() . '/config/app.php');
+    }
+}
+```
+
+`resetInstallScaffoldRanFlag()` clears the process-wide static flag in `EventSubscriber`, which is required when a
+single test dispatches multiple lifecycle events.
+
+## Fixtures
+
+Static fixtures under `tests/fixtures/providers/` are read-only sample provider packages used by manifest-loader and
+security tests. Keep them minimal — anything that needs a composer.json on disk belongs in a fixture; anything that can
+be built at runtime belongs in `FakeProjectBuilder`.
+
+## Adding a new test
+
+- **Testing a pure class?** Add a unit test mirroring the `src/` path.
+- **Testing a console controller?** Use or create a spy under `tests/support/Spies/`.
+- **Testing an event handler or multi-provider scenario?** Use `ComposerEventHarness` and dispatch
+  the real script event; do not call `Scaffolder::scaffold()` directly.
+- **Introducing a new persistent input?** Prefer `FakeProjectBuilder`/`FakeProjectBuilder::createComposerJson`
+  over static fixtures when the file only matters for one test.
+
+## Static analysis and style
+
+```bash
+vendor/bin/phpstan analyse                      # level max, zero tolerance
+vendor/bin/ecs check                            # PER-3 + PSR-12 + PHP-CS-Fixer
+vendor/bin/ecs check --fix                      # auto-fix style violations
+vendor/bin/infection                            # mutation testing
+```
+
+Failing static analysis is always a blocker. Do not suppress PHPStan errors with `@phpstan-ignore`; fix the underlying
+cause or narrow the type.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ tests when contributing.
 
 ## Suite layout
 
-```
+```text
 tests/
 ├── unit/                  # pure, fast unit tests per src/ namespace
 │   ├── Commands/          # console controllers via spies (no real stdout writes)
@@ -60,7 +60,7 @@ Functional tests spin up a **real `Composer\Composer` instance** against a fake 
 directory, seed its local repository with mock provider packages, and dispatch the same script events the plugin
 subscribes to in production. They exercise the entire chain
 
-```
+```text
 Script event → EventSubscriber → Scaffolder → modes → lock file
 ```
 

--- a/src/Commands/EjectController.php
+++ b/src/Commands/EjectController.php
@@ -23,7 +23,7 @@ use function sprintf;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class EjectController extends Controller
+class EjectController extends Controller
 {
     /**
      * When `true`, performs the ejection without prompting for confirmation.

--- a/src/Commands/ProvidersController.php
+++ b/src/Commands/ProvidersController.php
@@ -19,7 +19,7 @@ use yii\scaffold\Scaffold\Lock\LockFile;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class ProvidersController extends Controller
+class ProvidersController extends Controller
 {
     /**
      * Outputs a summary table of all providers tracked in `scaffold-lock.json`.

--- a/src/Commands/ReapplyController.php
+++ b/src/Commands/ReapplyController.php
@@ -28,7 +28,7 @@ use function sprintf;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class ReapplyController extends Controller
+class ReapplyController extends Controller
 {
     /**
      * When `true`, overwrites user-modified files without prompting.
@@ -36,8 +36,8 @@ final class ReapplyController extends Controller
     public bool $force = false;
 
     /**
-     * Optional provider package name filter (for example, `yii2-extensions/app-base`). When empty, all
-     * providers are processed.
+     * Optional provider package name filter (for example, `yii2-extensions/app-base`). When empty, all providers are
+     * processed.
      */
     public string $provider = '';
 

--- a/tests/support/Spies/EjectControllerSpy.php
+++ b/tests/support/Spies/EjectControllerSpy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support\Spies;
+
+use yii\scaffold\Commands\EjectController;
+
+use function strlen;
+
+/**
+ * Test double for {@see EjectController} that buffers `stdout`/`stderr` output into in-memory strings.
+ *
+ * Yii's base {@see \yii\console\Controller::stdout()} writes directly to the `STDOUT` stream, which bypasses PHPUnit
+ * output buffering. This spy overrides both writers so tests can assert on exact emitted content.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class EjectControllerSpy extends EjectController
+{
+    /**
+     * Accumulated `stderr` output.
+     */
+    public string $stderrBuffer = '';
+
+    /**
+     * Accumulated `stdout` output.
+     */
+    public string $stdoutBuffer = '';
+
+    public function stderr($string): int
+    {
+        $this->stderrBuffer .= $string;
+
+        return strlen($string);
+    }
+
+    public function stdout($string): int
+    {
+        $this->stdoutBuffer .= $string;
+
+        return strlen($string);
+    }
+}

--- a/tests/support/Spies/ProvidersControllerSpy.php
+++ b/tests/support/Spies/ProvidersControllerSpy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support\Spies;
+
+use yii\scaffold\Commands\ProvidersController;
+
+use function strlen;
+
+/**
+ * Test double for {@see ProvidersController} that buffers `stdout`/`stderr` output into in-memory strings.
+ *
+ * Yii's base {@see \yii\console\Controller::stdout()} writes directly to the `STDOUT` stream, which bypasses PHPUnit
+ * output buffering. This spy overrides both writers so tests can assert on exact emitted content.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class ProvidersControllerSpy extends ProvidersController
+{
+    /**
+     * Accumulated `stderr` output.
+     */
+    public string $stderrBuffer = '';
+
+    /**
+     * Accumulated `stdout` output.
+     */
+    public string $stdoutBuffer = '';
+
+    public function stderr($string): int
+    {
+        $this->stderrBuffer .= $string;
+
+        return strlen($string);
+    }
+
+    public function stdout($string): int
+    {
+        $this->stdoutBuffer .= $string;
+
+        return strlen($string);
+    }
+}

--- a/tests/support/Spies/ReapplyControllerSpy.php
+++ b/tests/support/Spies/ReapplyControllerSpy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support\Spies;
+
+use yii\scaffold\Commands\ReapplyController;
+
+use function strlen;
+
+/**
+ * Test double for {@see ReapplyController} that buffers `stdout`/`stderr` output into in-memory strings.
+ *
+ * Yii's base {@see \yii\console\Controller::stdout()} writes directly to the `STDOUT` stream, which bypasses PHPUnit
+ * output buffering. This spy overrides both writers so tests can assert on exact emitted content.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class ReapplyControllerSpy extends ReapplyController
+{
+    /**
+     * Accumulated `stderr` output.
+     */
+    public string $stderrBuffer = '';
+
+    /**
+     * Accumulated `stdout` output.
+     */
+    public string $stdoutBuffer = '';
+
+    public function stderr($string): int
+    {
+        $this->stderrBuffer .= $string;
+
+        return strlen($string);
+    }
+
+    public function stdout($string): int
+    {
+        $this->stdoutBuffer .= $string;
+
+        return strlen($string);
+    }
+}

--- a/tests/unit/Commands/EjectControllerTest.php
+++ b/tests/unit/Commands/EjectControllerTest.php
@@ -108,6 +108,11 @@ final class EjectControllerTest extends TestCase
             $diskFile,
             'The on-disk file must remain after ejection; only the lock entry is removed.',
         );
+        self::assertStringEqualsFile(
+            $diskFile,
+            'user content',
+            'The on-disk file content must remain byte-for-byte unchanged after ejection.',
+        );
         self::assertStringContainsString(
             'was not deleted from disk',
             $controller->stdoutBuffer,

--- a/tests/unit/Commands/EjectControllerTest.php
+++ b/tests/unit/Commands/EjectControllerTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Commands;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Yii;
+use yii\console\ExitCode;
+use yii\scaffold\Module;
+use yii\scaffold\Scaffold\Lock\LockFile;
+use yii\scaffold\tests\support\ConsoleApplicationTrait;
+use yii\scaffold\tests\support\Spies\EjectControllerSpy;
+
+/**
+ * Unit tests for {@see \yii\scaffold\Commands\EjectController} lock-entry removal behavior.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('commands')]
+final class EjectControllerTest extends TestCase
+{
+    use ConsoleApplicationTrait;
+
+    public function testDryRunLeavesLockUntouchedWithoutYes(): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $initial = [
+            'providers' => [],
+            'files' => [
+                'config/params.php' => [
+                    'hash' => 'sha256:abc',
+                    'provider' => 'pkg/name',
+                    'source' => 'stubs/config/params.php',
+                    'mode' => 'replace',
+                ],
+            ],
+        ];
+
+        $lock->write($initial);
+
+        $controller = $this->makeController(yes: false);
+
+        $exitCode = $controller->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            'Dry-run must succeed so users can preview the intended eject.',
+        );
+        self::assertStringContainsString(
+            'Would remove "config/params.php"',
+            $controller->stdoutBuffer,
+            'Dry-run output must advertise that the lock is not actually being modified.',
+        );
+        self::assertArrayHasKey(
+            'config/params.php',
+            (new LockFile($this->tempDir))->read()['files'],
+            'Dry-run must not persist any change to the lock file on disk.',
+        );
+    }
+
+    public function testEjectRemovesEntryAndPreservesFileOnDiskWithYes(): void
+    {
+        $diskFile = "{$this->tempDir}/config/params.php";
+
+        mkdir(dirname($diskFile), 0777, recursive: true);
+        file_put_contents($diskFile, 'user content');
+
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/name' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/name',
+                    ],
+                ],
+                'files' => [
+                    'config/params.php' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/config/params.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $controller = $this->makeController(yes: true);
+
+        $exitCode = $controller->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            "Confirmed ejection of a tracked file must return 'ExitCode::OK'.",
+        );
+        self::assertArrayNotHasKey(
+            'config/params.php',
+            (new LockFile($this->tempDir))->read()['files'],
+            "Tracked file entry must be removed from 'scaffold-lock.json' after a confirmed eject.",
+        );
+        self::assertFileExists(
+            $diskFile,
+            'The on-disk file must remain after ejection; only the lock entry is removed.',
+        );
+        self::assertStringContainsString(
+            'was not deleted from disk',
+            $controller->stdoutBuffer,
+            'Success message must explicitly reassure the user that the file is untouched on disk.',
+        );
+    }
+
+    public function testReturnsErrorWhenFileNotTracked(): void
+    {
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+
+        $controller = $this->makeController(yes: true);
+
+        $exitCode = $controller->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'Attempting to eject a destination that is not tracked must return a non-OK exit code.',
+        );
+        self::assertStringContainsString(
+            'is not tracked in scaffold-lock.json',
+            $controller->stderrBuffer,
+            'User must see a clear error when the file is not in the lock file.',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpConsoleApplication();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownConsoleApplication();
+    }
+
+    private function makeController(bool $yes): EjectControllerSpy
+    {
+        $module = Yii::$app->getModule('scaffold');
+
+        assert($module instanceof Module);
+
+        $controller = new EjectControllerSpy('eject', $module);
+
+        $controller->yes = $yes;
+
+        return $controller;
+    }
+}

--- a/tests/unit/Commands/ProvidersControllerTest.php
+++ b/tests/unit/Commands/ProvidersControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Commands;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Yii;
+use yii\console\ExitCode;
+use yii\scaffold\Module;
+use yii\scaffold\Scaffold\Lock\LockFile;
+use yii\scaffold\tests\support\ConsoleApplicationTrait;
+use yii\scaffold\tests\support\Spies\ProvidersControllerSpy;
+
+/**
+ * Unit tests for {@see \yii\scaffold\Commands\ProvidersController} provider listing behavior.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('commands')]
+final class ProvidersControllerTest extends TestCase
+{
+    use ConsoleApplicationTrait;
+
+    public function testAggregatesFileCountsPerProvider(): void
+    {
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/a' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/a',
+                    ],
+                    'pkg/b' => [
+                        'version' => '2.0.0',
+                        'path' => 'vendor/pkg/b',
+                    ],
+                ],
+                'files' => [
+                    'a1.txt' => [
+                        'hash' => 'sha256:a1',
+                        'provider' => 'pkg/a',
+                        'source' => 'stubs/a1.txt',
+                        'mode' => 'replace',
+                    ],
+                    'a2.txt' => [
+                        'hash' => 'sha256:a2',
+                        'provider' => 'pkg/a',
+                        'source' => 'stubs/a2.txt',
+                        'mode' => 'preserve',
+                    ],
+                    'b1.txt' => [
+                        'hash' => 'sha256:b1',
+                        'provider' => 'pkg/b',
+                        'source' => 'stubs/b1.txt',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $controller = $this->makeController();
+
+        $controller->actionIndex();
+
+        self::assertMatchesRegularExpression(
+            '/pkg\/a\s+2/',
+            $controller->stdoutBuffer,
+            "Provider with two tracked files must report a count of '2'.",
+        );
+        self::assertMatchesRegularExpression(
+            '/pkg\/b\s+1/',
+            $controller->stdoutBuffer,
+            "Provider with a single tracked file must report a count of '1'.",
+        );
+    }
+
+    public function testPrintsEmptyMessageWhenNoProvidersTracked(): void
+    {
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+
+        $controller = $this->makeController();
+
+        $controller->actionIndex();
+
+        self::assertStringContainsString(
+            'No providers tracked in scaffold-lock.json',
+            $controller->stdoutBuffer,
+            'Empty-lock case must emit the user-facing no-providers message instead of an empty table.',
+        );
+    }
+
+    public function testReturnsOkExitCode(): void
+    {
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+
+        self::assertSame(
+            ExitCode::OK,
+            $this->makeController()->actionIndex(),
+            'Providers command must always return ExitCode::OK regardless of whether any providers are tracked.',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpConsoleApplication();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownConsoleApplication();
+    }
+
+    private function makeController(): ProvidersControllerSpy
+    {
+        $module = Yii::$app->getModule('scaffold');
+
+        assert($module instanceof Module);
+
+        return new ProvidersControllerSpy('providers', $module);
+    }
+}

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Commands;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Yii;
+use yii\console\ExitCode;
+use yii\scaffold\Module;
+use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
+use yii\scaffold\tests\support\ConsoleApplicationTrait;
+use yii\scaffold\tests\support\Spies\ReapplyControllerSpy;
+
+/**
+ * Unit tests for {@see \yii\scaffold\Commands\ReapplyController} scaffold re-application behavior.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('commands')]
+final class ReapplyControllerTest extends TestCase
+{
+    use ConsoleApplicationTrait;
+
+    public function testAppendModeCannotBeReapplied(): void
+    {
+        $this->seedProviderStub('stubs/.gitignore', "/runtime/\n");
+        $this->writeLockEntry('.gitignore', "/runtime/\n", 'append');
+
+        $controller = $this->makeController(force: false);
+
+        $exitCode = $controller->actionIndex();
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            "Reapply must return 'ExitCode::OK' even when append-mode entries are present; they are simply skipped.",
+        );
+        self::assertStringContainsString(
+            'uses mode "append" and cannot be safely reapplied',
+            $controller->stdoutBuffer,
+            'Append mode must emit a clear skip message rather than silently continuing.',
+        );
+    }
+
+    public function testForceOverwritesUserModifiedFileAndUpdatesLockHash(): void
+    {
+        $stubContent = "stub v2\n";
+        $userContent = "user-edited\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stubContent);
+        $this->writeLockEntry('config/params.php', "stub v1\n", 'replace');
+
+        $destination = "{$this->tempDir}/config/params.php";
+        mkdir(dirname($destination), 0777, recursive: true);
+        file_put_contents($destination, $userContent);
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex();
+
+        self::assertSame(
+            $stubContent,
+            file_get_contents($destination),
+            "With '--force', a user-modified replace-mode destination must be overwritten with the current stub "
+            . 'content.',
+        );
+
+        $lockHash = (new LockFile($this->tempDir))->getHashAtScaffold('config/params.php');
+
+        self::assertSame(
+            (new Hasher())->hash($destination),
+            $lockHash,
+            'Lock hash must be updated to reflect the content actually written during reapply.',
+        );
+    }
+
+    public function testPreserveModeIsSkippedWithoutForce(): void
+    {
+        $this->seedProviderStub('stubs/config/params.php', "stub\n");
+        $this->writeLockEntry('config/params.php', "stub\n", 'preserve');
+
+        $destination = "{$this->tempDir}/config/params.php";
+
+        mkdir(dirname($destination), 0777, recursive: true);
+        file_put_contents($destination, "kept by user\n");
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex();
+
+        self::assertSame(
+            "kept by user\n",
+            file_get_contents($destination),
+            "Preserve mode must leave the on-disk file untouched unless '--force' is explicitly requested.",
+        );
+        self::assertStringContainsString(
+            'uses mode "preserve". Use --force to overwrite',
+            $controller->stdoutBuffer,
+            "Preserve-mode skip must guide the user toward the '--force' escape hatch.",
+        );
+    }
+
+    public function testProviderFilterOnlyProcessesMatchingEntries(): void
+    {
+        $this->seedProviderStub('stubs/a.txt', 'content a', providerName: 'pkg/a');
+        $this->seedProviderStub('stubs/b.txt', 'content b', providerName: 'pkg/b');
+
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/a' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/a',
+                    ],
+                    'pkg/b' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/b',
+                    ],
+                ],
+                'files' => [
+                    'a.txt' => [
+                        'hash' => 'sha256:' . hash('sha256', 'content a'),
+                        'provider' => 'pkg/a',
+                        'source' => 'stubs/a.txt',
+                        'mode' => 'replace',
+                    ],
+                    'b.txt' => [
+                        'hash' => 'sha256:' . hash('sha256', 'content b'),
+                        'provider' => 'pkg/b',
+                        'source' => 'stubs/b.txt',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $controller = $this->makeController(force: false, provider: 'pkg/a');
+
+        $controller->actionIndex();
+
+        self::assertFileExists(
+            "{$this->tempDir}/a.txt",
+            'Files from the filtered provider must be reapplied.',
+        );
+        self::assertFileDoesNotExist(
+            "{$this->tempDir}/b.txt",
+            "Files from non-matching providers must be skipped entirely when '--provider' filter is active.",
+        );
+    }
+
+    public function testReturnsErrorWhenFilterMatchesNothing(): void
+    {
+        $this->writeLockEntry('config/params.php', "stub\n", 'replace');
+
+        $controller = $this->makeController(force: false);
+
+        $exitCode = $controller->actionIndex('does/not/exist.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'A filter that matches zero tracked files must surface an error so CI fails loudly on typos.',
+        );
+        self::assertStringContainsString(
+            'No tracked files matched the given filter',
+            $controller->stderrBuffer,
+            'User must see a clear error when the filter matches no entries.',
+        );
+    }
+
+    public function testSkipsUserModifiedFileWithoutForce(): void
+    {
+        $this->seedProviderStub('stubs/config/params.php', "stub v1\n");
+        $this->writeLockEntry('config/params.php', "stub v1\n", 'replace');
+
+        $destination = "{$this->tempDir}/config/params.php";
+
+        mkdir(dirname($destination), 0777, recursive: true);
+        file_put_contents($destination, "user edit\n");
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex();
+
+        self::assertSame(
+            "user edit\n",
+            file_get_contents($destination),
+            "Without '--force', a user-modified replace-mode destination must not be overwritten by reapply.",
+        );
+        self::assertStringContainsString(
+            'is user-modified. Use --force to overwrite',
+            $controller->stdoutBuffer,
+            "User-modified skip must name the '--force' flag as the escape hatch.",
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpConsoleApplication();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownConsoleApplication();
+    }
+
+    private function makeController(bool $force, string $provider = ''): ReapplyControllerSpy
+    {
+        $module = Yii::$app->getModule('scaffold');
+
+        assert($module instanceof Module);
+
+        $controller = new ReapplyControllerSpy('reapply', $module);
+
+        $controller->force = $force;
+        $controller->provider = $provider;
+
+        return $controller;
+    }
+
+    private function seedProviderStub(
+        string $relPath,
+        string $content,
+        string $providerName = 'pkg/name',
+    ): void {
+        $stubPath = "{$this->tempDir}/vendor/{$providerName}/{$relPath}";
+
+        mkdir(dirname($stubPath), 0777, recursive: true);
+
+        file_put_contents($stubPath, $content);
+    }
+
+    private function writeLockEntry(
+        string $destination,
+        string $hashedContent,
+        string $mode,
+        string $providerName = 'pkg/name',
+    ): void {
+        $lock = new LockFile($this->tempDir);
+
+        $existing = $lock->read();
+
+        $existing['providers'][$providerName] = [
+            'version' => '1.0.0',
+            'path' => "vendor/{$providerName}",
+        ];
+        $existing['files'][$destination] = [
+            'hash' => 'sha256:' . hash('sha256', $hashedContent),
+            'provider' => $providerName,
+            'source' => 'stubs/' . ltrim($destination, '/'),
+            'mode' => $mode,
+        ];
+
+        $lock->write($existing);
+    }
+}

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -25,10 +25,12 @@ final class ReapplyControllerTest extends TestCase
 {
     use ConsoleApplicationTrait;
 
-    public function testAppendModeCannotBeReapplied(): void
+    public function testAppendAndPrependModesCannotBeReapplied(): void
     {
         $this->seedProviderStub('stubs/.gitignore', "/runtime/\n");
         $this->writeLockEntry('.gitignore', "/runtime/\n", 'append');
+        $this->seedProviderStub('stubs/.env', "APP_ENV=dev\n");
+        $this->writeLockEntry('.env', "APP_ENV=dev\n", 'prepend');
 
         $controller = $this->makeController(force: false);
 
@@ -37,12 +39,17 @@ final class ReapplyControllerTest extends TestCase
         self::assertSame(
             ExitCode::OK,
             $exitCode,
-            "Reapply must return 'ExitCode::OK' even when append-mode entries are present; they are simply skipped.",
+            "Reapply must return 'ExitCode::OK' even when append/prepend entries are present; they are simply skipped.",
         );
         self::assertStringContainsString(
             'uses mode "append" and cannot be safely reapplied',
             $controller->stdoutBuffer,
             'Append mode must emit a clear skip message rather than silently continuing.',
+        );
+        self::assertStringContainsString(
+            'uses mode "prepend" and cannot be safely reapplied',
+            $controller->stdoutBuffer,
+            'Prepend mode must emit a clear skip message rather than silently continuing.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
