### PR TITLE
tests: raise suite to 100% line/method/class coverage by exercising error paths via `xepozz/internal-mocker` intercepts and removing dead defensive code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - feat: record `providers[name]` in `scaffold-lock.json` as `{version, path}` with project-root-relative paths so committed locks stay stable across machines.
 - test: add real-Composer functional tests for `post-install-cmd`, `post-create-project-cmd`, and multi-layer provider precedence.
 - test: cover `eject`, `providers`, and `reapply` console commands via buffered-output spies (un-final'd for subclassing); add `docs/testing.md` and a lock-example fix.
+- test: raise suite to 100% line/method/class coverage by exercising error paths via `xepozz/internal-mocker` intercepts and removing dead defensive code.

--- a/src/Commands/DiffController.php
+++ b/src/Commands/DiffController.php
@@ -27,7 +27,7 @@ use function sprintf;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class DiffController extends Controller
+class DiffController extends Controller
 {
     /**
      * Outputs the diff between the provider stub and the current file for `$file`.

--- a/src/Commands/StatusController.php
+++ b/src/Commands/StatusController.php
@@ -25,7 +25,7 @@ use function sprintf;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class StatusController extends Controller
+class StatusController extends Controller
 {
     /**
      * Outputs a table of all scaffold-tracked files with their sync status.

--- a/src/Scaffold/Modes/PrependMode.php
+++ b/src/Scaffold/Modes/PrependMode.php
@@ -9,9 +9,6 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
-use function file_exists;
-use function file_get_contents;
-use function file_put_contents;
 use function sprintf;
 
 /**

--- a/src/Scaffold/Modes/PreserveMode.php
+++ b/src/Scaffold/Modes/PreserveMode.php
@@ -9,8 +9,6 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
-use function copy;
-use function file_exists;
 use function sprintf;
 
 /**

--- a/src/Scaffold/Modes/ReplaceMode.php
+++ b/src/Scaffold/Modes/ReplaceMode.php
@@ -9,8 +9,6 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
-use function copy;
-use function file_exists;
 use function sprintf;
 
 /**

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -214,6 +214,25 @@ final class Scaffolder
     }
 
     /**
+     * Byte-exact or case-insensitive prefix match, depending on `$caseInsensitive`.
+     *
+     * Extracted from {@see self::toProjectRelative()} so both branches remain reachable under tests regardless of the
+     * host platform's `DIRECTORY_SEPARATOR`.
+     *
+     * @param string $haystack String to inspect.
+     * @param string $needle Prefix to look for.
+     * @param bool $caseInsensitive `true` to match case-insensitively (Windows/NTFS semantics), `false` for byte-exact.
+     *
+     * @return bool `true` when `$haystack` starts with `$needle` under the requested comparison.
+     */
+    private static function prefixMatches(string $haystack, string $needle, bool $caseInsensitive): bool
+    {
+        return $caseInsensitive
+            ? stripos($haystack, $needle) === 0
+            : str_starts_with($haystack, $needle);
+    }
+
+    /**
      * Resolves a mode string to its corresponding ModeInterface implementation.
      *
      * @param string $mode Mode name (for example, 'replace', 'preserve', 'append', 'prepend').
@@ -245,13 +264,8 @@ final class Scaffolder
     {
         $normalizedRoot = rtrim(str_replace('\\', '/', $projectRoot), '/') . '/';
         $normalizedPath = str_replace('\\', '/', $absolutePath);
-        $haystack = $normalizedPath . '/';
 
-        $matches = DIRECTORY_SEPARATOR === '\\'
-            ? stripos($haystack, $normalizedRoot) === 0
-            : str_starts_with($haystack, $normalizedRoot);
-
-        if ($matches) {
+        if (self::prefixMatches($normalizedPath . '/', $normalizedRoot, DIRECTORY_SEPARATOR === '\\')) {
             return rtrim(substr($normalizedPath, strlen($normalizedRoot)), '/');
         }
 

--- a/src/Security/PathValidator.php
+++ b/src/Security/PathValidator.php
@@ -40,13 +40,12 @@ final class PathValidator
             );
         }
 
+        /**
+         * After assertRelative + assertNoTraversal the relative segment cannot escape the base, so normalizePath's
+         * literal concatenation is guaranteed to stay under $realRoot; the remaining risk is a symlinked ancestor,
+         * which assertNoSymlinkEscape covers below.
+         */
         $normalized = $this->normalizePath($realRoot, $destination);
-
-        if (!str_starts_with($normalized . DIRECTORY_SEPARATOR, $realRoot . DIRECTORY_SEPARATOR)) {
-            throw new RuntimeException(
-                sprintf('Destination path escapes the project root: "%s".', $destination),
-            );
-        }
 
         $this->assertNoSymlinkEscape($normalized, $realRoot, 'destination', $destination);
     }
@@ -72,13 +71,12 @@ final class PathValidator
             );
         }
 
+        /**
+         * See validateDestination: the redundant containment check was removed because normalizePath's literal
+         * concatenation cannot escape $realRoot after assertRelative + assertNoTraversal; symlink ancestors are
+         * still verified below.
+         */
         $normalized = $this->normalizePath($realRoot, $source);
-
-        if (!str_starts_with($normalized . DIRECTORY_SEPARATOR, $realRoot . DIRECTORY_SEPARATOR)) {
-            throw new RuntimeException(
-                sprintf('Source path escapes the provider root: "%s".', $source),
-            );
-        }
 
         $this->assertNoSymlinkEscape($normalized, $realRoot, 'source', $source);
     }
@@ -145,13 +143,11 @@ final class PathValidator
      */
     private function assertNoTraversal(string $path, string $context): void
     {
-        $segments = preg_split('#[/\\\\]#', $path);
-
-        if ($segments === false) {
-            throw new RuntimeException(
-                sprintf('Unable to validate path for traversal in %s: "%s".', $context, $path),
-            );
-        }
+        /**
+         * Normalize both separators to `/` then split; `explode` always returns array<string>, avoiding the
+         * defensive false-branch that `preg_split` would have produced for malformed input.
+         */
+        $segments = explode('/', str_replace('\\', '/', $path));
 
         foreach ($segments as $segment) {
             if ($segment === '..') {

--- a/tests/functional/ComposerInstallTest.php
+++ b/tests/functional/ComposerInstallTest.php
@@ -230,7 +230,7 @@ final class ComposerInstallTest extends TestCase
         $builder->createStubFile(
             'demo/scaffold',
             'stubs/.env.dist',
-            "APP_ENV=dev\n"
+            "APP_ENV=dev\n",
         );
         $builder->createComposerJson(
             [

--- a/tests/functional/ComposerInstallTest.php
+++ b/tests/functional/ComposerInstallTest.php
@@ -28,8 +28,16 @@ final class ComposerInstallTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/config/params.php', "<?php return ['adminEmail' => 'a@b.c'];\n");
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/config/params.php',
+            "<?php return ['adminEmail' => 'a@b.c'];\n",
+        );
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/.gitignore',
+            "/runtime/\n",
+        );
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -91,11 +99,139 @@ final class ComposerInstallTest extends TestCase
         );
     }
 
+    public function testNonStringAllowedPackagesEntryIsReportedAndIgnored(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/config/params.php',
+            "<?php return [];\n",
+        );
+        $builder->createComposerJson(
+            [
+                'name' => 'demo/smoke-project',
+                'config' => ['vendor-dir' => $builder->getVendorDir()],
+                'extra' => [
+                    'scaffold' => [
+                        // `42` is not a string and must be rejected without aborting the run.
+                        'allowed-packages' => ['demo/scaffold', 42],
+                    ],
+                ],
+            ],
+        );
+
+        $io = new BufferIO();
+
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->addMockProvider(
+            $composer,
+            'demo/scaffold',
+            [
+                'file-mapping' => [
+                    'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'preserve'],
+                ],
+            ],
+        );
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
+
+        self::assertStringContainsString(
+            'Non-string entry in allowed-packages ignored',
+            $io->getOutput(),
+            'Non-string entries in allowed-packages must be reported so configuration errors are visible.',
+        );
+        self::assertFileExists(
+            $builder->getProjectRoot() . '/config/params.php',
+            'Valid providers must still be scaffolded even when a sibling allowed-packages entry is malformed.',
+        );
+    }
+
+    public function testNoScaffoldExtraIsAcceptedAndTreatedAsEmpty(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        /**
+         * `composer.json` has no `extra.scaffold` key at all. runScaffold must continue without errors, emit the
+         * no-config notice inside Scaffolder, and leave the project untouched.
+         */
+        $builder->createComposerJson(
+            [
+                'name' => 'demo/smoke-project',
+                'config' => ['vendor-dir' => $builder->getVendorDir()],
+            ],
+        );
+
+        $io = new BufferIO();
+
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
+
+        self::assertStringContainsString(
+            'No extra.scaffold configuration found',
+            $io->getOutput(),
+            'Projects without `extra.scaffold` must still dispatch the handler; it must gracefully emit the no-config '
+            . 'notice instead of raising an error.',
+        );
+    }
+
+    public function testPostUpdateTriggersPartialScaffold(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/config/params.php',
+            "<?php return [];\n",
+        );
+        $builder->createComposerJson(
+            [
+                'name' => 'demo/smoke-project',
+                'config' => ['vendor-dir' => $builder->getVendorDir()],
+                'extra' => [
+                    'scaffold' => [
+                        'allowed-packages' => [
+                            'demo/scaffold',
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $io = new BufferIO();
+
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->addMockProvider(
+            $composer,
+            'demo/scaffold',
+            [
+                'file-mapping' => [
+                    'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'preserve'],
+                ],
+            ],
+        );
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostUpdate($this->makePostUpdateEvent($composer, $io));
+
+        self::assertFileExists(
+            $builder->getProjectRoot() . '/config/params.php',
+            "'post-update-cmd' must dispatch the same partial scaffold flow as 'post-install-cmd'.",
+        );
+    }
+
     public function testReplaceModeWarnsAndSkipsWhenUserModifiedBetweenRuns(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.env.dist', "APP_ENV=dev\n");
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/.env.dist',
+            "APP_ENV=dev\n"
+        );
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -155,6 +291,89 @@ final class ComposerInstallTest extends TestCase
             'USER_EDIT=1',
             $envContent,
             'Replace mode must preserve the user edit instead of reverting to the provider stub.',
+        );
+    }
+
+    public function testScaffolderExceptionIsLoggedAndHandlerDoesNotCrash(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        /**
+         * `pre-populate` scaffold-lock.json with malformed JSON so LockFile::read() throws inside
+         * `Scaffolder::scaffold()`. The EventSubscriber must catch the Throwable and log
+         * `[scaffold] Scaffolding aborted: ...`.
+         */
+        file_put_contents("{$builder->getProjectRoot()}/scaffold-lock.json", '{ not valid json');
+
+        $builder->createStubFile(
+            'demo/scaffold',
+            'stubs/config/params.php',
+            "<?php return [];\n",
+        );
+        $builder->createComposerJson(
+            [
+                'name' => 'demo/smoke-project',
+                'config' => ['vendor-dir' => $builder->getVendorDir()],
+                'extra' => [
+                    'scaffold' => [
+                        'allowed-packages' => [
+                            'demo/scaffold',
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $io = new BufferIO();
+
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->addMockProvider(
+            $composer,
+            'demo/scaffold',
+            [
+                'file-mapping' => [
+                    'config/params.php' => [
+                        'source' => 'stubs/config/params.php',
+                        'mode' => 'preserve',
+                    ],
+                ],
+            ],
+        );
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
+
+        self::assertStringContainsString(
+            'Scaffolding aborted',
+            $io->getOutput(),
+            'An exception bubbling out of Scaffolder must be caught and reported without crashing Composer.',
+        );
+    }
+
+    public function testScaffoldExtraWithoutAllowedPackagesKeyIsTreatedAsEmpty(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $builder->createComposerJson(
+            [
+                'name' => 'demo/smoke-project',
+                'config' => ['vendor-dir' => $builder->getVendorDir()],
+                // `extra.scaffold` is present but `allowed-packages` is missing entirely.
+                'extra' => ['scaffold' => []],
+            ],
+        );
+
+        $io = new BufferIO();
+
+        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
+        $this->resetInstallScaffoldRanFlag();
+
+        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
+
+        self::assertStringContainsString(
+            'No allowed-packages configured',
+            $io->getOutput(),
+            "A scaffold extra without the 'allowed-packages' key must produce the allowed-packages skip message.",
         );
     }
 

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\functional;
 
-use Composer\IO\{IOInterface, NullIO};
+use Composer\IO\{BufferIO, IOInterface, NullIO};
 use Composer\Package\PackageInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use yii\scaffold\Manifest\{ManifestLoader, ManifestSchema};
 use yii\scaffold\Scaffold\{Applier, Scaffolder};
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
@@ -25,6 +26,36 @@ use yii\scaffold\tests\support\{FakeProjectBuilder, TempDirectoryTrait};
 final class ScaffolderTest extends TestCase
 {
     use TempDirectoryTrait;
+
+    public function testAllowedPackageNotInstalledEmitsSkipMessage(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        // root authorizes a provider that was never added to the installed-packages list.
+        $root = $this->makeRootPackage(['yii2-extensions/missing']);
+
+        $io = new BufferIO();
+        $scaffolder = new Scaffolder(
+            new ManifestLoader(new ManifestSchema()),
+            new Applier(
+                new PackageAllowlist(['yii2-extensions/missing']),
+                new PathValidator(),
+                new Hasher(),
+                $io,
+            ),
+            new LockFile($builder->getProjectRoot()),
+            $io,
+        );
+
+        $scaffolder->scaffold($root, [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertStringContainsString(
+            'Provider "yii2-extensions/missing" is not installed',
+            $io->getOutput(),
+            'Allowed providers that Composer did not install must emit a clear skip message so typos in '
+            . "'allowed-packages' are noticed.",
+        );
+    }
 
     public function testAppendModeAppliedOnFullScaffoldEvenIfAlreadyInLock(): void
     {
@@ -101,6 +132,52 @@ final class ScaffolderTest extends TestCase
         );
     }
 
+    public function testApplierExceptionIsLoggedAndScaffoldingContinues(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        /**
+         * An allowlist of `['safe/provider']` authorizes only that provider; when the actual provider is
+         * `yii2-extensions/test`, the Applier will throw with "Package not allowed" inside apply(). That throw must be
+         * caught by the Scaffolder loop and reported via writeError.
+         */
+        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'content');
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/test',
+            [
+                'scaffold' => [
+                    'file-mapping' => [
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
+                    ],
+                ],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/test']);
+
+        $io = new BufferIO();
+
+        // allowlist only admits a DIFFERENT provider, so assertAllowed throws RuntimeException during apply().
+        $scaffolder = new Scaffolder(
+            new ManifestLoader(new ManifestSchema()),
+            new Applier(new PackageAllowlist(['safe/other']), new PathValidator(), new Hasher(), $io),
+            new LockFile($builder->getProjectRoot()),
+            $io,
+        );
+
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertStringContainsString(
+            'Error applying "app.php"',
+            $io->getOutput(),
+            'Applier exceptions must be caught per-destination, reported via writeError, and must not abort the rest '
+            . 'of the scaffold loop.',
+        );
+    }
+
     public function testEmptyAllowedPackagesIsNoop(): void
     {
         $this->expectNotToPerformAssertions();
@@ -111,6 +188,62 @@ final class ScaffolderTest extends TestCase
         $this
             ->makeScaffolder([], $builder)
             ->scaffold($root, [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+    }
+
+    public function testEmptyAllowedPackagesListEmitsSkipMessage(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        // root with `extra.scaffold` present but the allowed-packages list explicitly empty.
+        $root = self::createStub(PackageInterface::class);
+        $root->method('getExtra')->willReturn(['scaffold' => ['allowed-packages' => []]]);
+
+        $io = new BufferIO();
+        $scaffolder = new Scaffolder(
+            new ManifestLoader(new ManifestSchema()),
+            new Applier(new PackageAllowlist([]), new PathValidator(), new Hasher(), $io),
+            new LockFile($builder->getProjectRoot()),
+            $io,
+        );
+
+        $scaffolder->scaffold($root, [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertStringContainsString(
+            'No allowed-packages configured',
+            $io->getOutput(),
+            'Empty allowed-packages list (as opposed to missing scaffold extra) must emit the configured-but-empty '
+            . 'skip message.',
+        );
+    }
+
+    public function testFailedManifestLoadIsLoggedAndSkippedInsteadOfFatal(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        $provider = $this->makeProviderPackage(
+            'yii2-extensions/bad',
+            [
+                // `manifest: "../escape.json"` triggers a traversal RuntimeException inside the loader.
+                'scaffold' => ['manifest' => '../escape.json'],
+            ],
+        );
+        $root = $this->makeRootPackage(['yii2-extensions/bad']);
+
+        $io = new BufferIO();
+        $scaffolder = new Scaffolder(
+            new ManifestLoader(new ManifestSchema()),
+            new Applier(new PackageAllowlist(['yii2-extensions/bad']), new PathValidator(), new Hasher(), $io),
+            new LockFile($builder->getProjectRoot()),
+            $io,
+        );
+
+        $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        self::assertStringContainsString(
+            'Failed to load manifest for "yii2-extensions/bad"',
+            $io->getOutput(),
+            'A manifest-loader exception must be caught and reported per-provider rather than aborting the entire run.',
+        );
     }
 
     public function testFirstScaffoldPersistsProviderPathInLock(): void
@@ -161,8 +294,10 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        // simulate the realistic layout where vendor is nested under the project root; the scaffolder must record a
-        // relative path so the committed lock stays stable across machines.
+        /**
+         * Simulate the realistic layout where vendor is nested under the project root; the scaffolder must record a
+         * relative path so the committed lock stays stable across machines.
+         */
         $providerRootInsideProject = $builder->getProjectRoot() . '/vendor/yii2-extensions/test';
 
         mkdir($providerRootInsideProject . '/stubs', 0777, recursive: true);
@@ -173,7 +308,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
@@ -281,7 +419,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'nginx.conf' => ['source' => 'stubs/nginx.conf', 'mode' => 'replace'],
+                        'nginx.conf' => [
+                            'source' => 'stubs/nginx.conf',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
@@ -316,6 +457,7 @@ final class ScaffolderTest extends TestCase
         $builder = new FakeProjectBuilder($this->tempDir);
 
         $root = self::createStub(PackageInterface::class);
+
         $root->method('getExtra')->willReturn([]);
 
         $io = $this->createMock(IOInterface::class);
@@ -344,8 +486,14 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'a.php' => ['source' => 'stubs/a.php', 'mode' => 'replace'],
-                        'b.php' => ['source' => 'stubs/b.php', 'mode' => 'replace'],
+                        'a.php' => [
+                            'source' => 'stubs/a.php',
+                            'mode' => 'replace',
+                        ],
+                        'b.php' => [
+                            'source' => 'stubs/b.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
@@ -387,6 +535,34 @@ final class ScaffolderTest extends TestCase
             ->scaffold($this->makeRootPackage([]), [], $builder->getProjectRoot(), $builder->getVendorDir(), true);
     }
 
+    public function testPrefixMatchesHonorsCaseInsensitiveFlag(): void
+    {
+        $method = new ReflectionMethod(Scaffolder::class, 'prefixMatches');
+
+        // case-sensitive branch matches identical casing but rejects differing casing.
+        self::assertTrue(
+            (bool) $method->invoke(null, '/Project/vendor/foo', '/Project/', false),
+            'Byte-exact comparison must accept an exact casing prefix.',
+        );
+        self::assertFalse(
+            (bool) $method->invoke(null, '/project/vendor/foo', '/Project/', false),
+            'Byte-exact comparison must reject a prefix that only differs in casing.',
+        );
+
+        /**
+         * case-insensitive branch is the Windows path; it must match regardless of casing. Covers the otherwise
+         * Linux-unreachable stripos branch used for NTFS compatibility.
+         */
+        self::assertTrue(
+            (bool) $method->invoke(null, '/project/vendor/foo', '/Project/', true),
+            'Case-insensitive comparison must accept a prefix that only differs in casing.',
+        );
+        self::assertFalse(
+            (bool) $method->invoke(null, '/elsewhere/vendor/foo', '/Project/', true),
+            'Case-insensitive comparison must still reject a prefix that is genuinely different.',
+        );
+    }
+
     public function testPrependModeSkippedOnPartialRunWhenAlreadyInLock(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
@@ -399,7 +575,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'prepend.txt' => ['source' => 'stubs/prepend.txt', 'mode' => 'prepend'],
+                        'prepend.txt' => [
+                            'source' => 'stubs/prepend.txt',
+                            'mode' => 'prepend',
+                        ],
                     ],
                 ],
             ],
@@ -408,12 +587,12 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // First run records a lock entry for the prepend mapping.
+        // first run records a lock entry for the prepend mapping.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/prepend.txt');
 
-        // Partial run must leave the prepended file untouched because it already lives in the lock.
+        // ´artial run must leave the prepended file untouched because it already lives in the lock.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
 
         self::assertSame(
@@ -435,21 +614,23 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                        'config.php' => [
+                            'source' => 'stubs/config.php',
+                            'mode' => 'preserve',
+                        ],
                     ],
                 ],
             ],
         );
-
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // First run records the current hash in the lock.
+        // first run records the current hash in the lock.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $initialHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('config.php');
 
-        // User modifies the file in place; a second preserve run must NOT overwrite the lock entry.
+        // user modifies the file in place; a second preserve run must NOT overwrite the lock entry.
         file_put_contents($builder->getProjectRoot() . '/config.php', 'user-modified');
 
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -473,7 +654,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'preserve'],
+                        'config/params.php' => [
+                            'source' => 'stubs/config/params.php',
+                            'mode' => 'preserve',
+                        ],
                     ],
                 ],
             ],
@@ -517,7 +701,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                        'config.php' => [
+                            'source' => 'stubs/config.php',
+                            'mode' => 'preserve',
+                        ],
                     ],
                 ],
             ],
@@ -564,7 +751,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'replace'],
+                        'config/params.php' => [
+                            'source' => 'stubs/config/params.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
@@ -595,7 +785,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'app.php' => ['source' => 'stubs/app.php', 'mode' => 'replace'],
+                        'app.php' => [
+                            'source' => 'stubs/app.php',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],
@@ -607,9 +800,8 @@ final class ScaffolderTest extends TestCase
 
         $firstHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
 
-        // Change the stub so the second run writes different content.
+        // change the stub so the second run writes different content.
         $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'v2');
-
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $secondHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
@@ -635,8 +827,10 @@ final class ScaffolderTest extends TestCase
 
         $userHash = (new Hasher())->hash($builder->getProjectRoot() . '/config.php');
 
-        // pre-populate the lock with an outdated provider path but a correct file entry. The upcoming scaffold run must
-        // only set `$dirty = true` through the provider-path branch (L141) — the preserve branch leaves `$dirty` alone.
+        /**
+         * pre-populate the lock with an outdated provider path but a correct file entry. The upcoming scaffold run must
+         * only set `$dirty = true` through the provider-path branch (L141) — the preserve branch leaves `$dirty` alone.
+         */
         (new LockFile($builder->getProjectRoot()))->write(
             [
                 'providers' => [
@@ -658,7 +852,10 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'config.php' => ['source' => 'stubs/config.php', 'mode' => 'preserve'],
+                        'config.php' => [
+                            'source' => 'stubs/config.php',
+                            'mode' => 'preserve',
+                        ],
                     ],
                 ],
             ],
@@ -695,8 +892,14 @@ final class ScaffolderTest extends TestCase
             [
                 'scaffold' => [
                     'file-mapping' => [
-                        'append.txt' => ['source' => 'stubs/append.txt', 'mode' => 'append'],
-                        'fresh.txt' => ['source' => 'stubs/fresh.txt', 'mode' => 'replace'],
+                        'append.txt' => [
+                            'source' => 'stubs/append.txt',
+                            'mode' => 'append',
+                        ],
+                        'fresh.txt' => [
+                            'source' => 'stubs/fresh.txt',
+                            'mode' => 'replace',
+                        ],
                     ],
                 ],
             ],

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -122,7 +122,7 @@ final class ScaffolderTest extends TestCase
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/.gitignore');
 
-        // second run: partial (install) — append is already in lock, must be skipped.
+        // second run: partial (install) append is already in lock, must be skipped.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
 
         self::assertSame(
@@ -829,7 +829,7 @@ final class ScaffolderTest extends TestCase
 
         /**
          * pre-populate the lock with an outdated provider path but a correct file entry. The upcoming scaffold run must
-         * only set `$dirty = true` through the provider-path branch (L141) — the preserve branch leaves `$dirty` alone.
+         * only set `$dirty = true` through the provider-path branch (L141) the preserve branch leaves `$dirty` alone.
          */
         (new LockFile($builder->getProjectRoot()))->write(
             [

--- a/tests/support/ConsoleApplicationTrait.php
+++ b/tests/support/ConsoleApplicationTrait.php
@@ -24,7 +24,7 @@ trait ConsoleApplicationTrait
     {
         $this->setUpTempDirectory();
 
-        // intentionally not assigned — Application::__construct() sets Yii::$app as a side effect.
+        // intentionally not assigned Application::__construct() sets Yii::$app as a side effect.
         new Application(
             [
                 'id' => 'scaffold-test',

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -8,6 +8,7 @@ use PHPUnit\Event\Test\{Finished, FinishedSubscriber, PreparationStarted, Prepar
 use PHPUnit\Event\TestSuite\{Started, StartedSubscriber};
 use PHPUnit\Runner\Extension\{Extension, Facade, ParameterCollection};
 use PHPUnit\TextUI\Configuration\Configuration;
+use ReflectionClass;
 use Xepozz\InternalMocker\{Mocker, MockerState};
 
 /**
@@ -38,12 +39,14 @@ final class MockerExtension implements Extension
                 public function notify(PreparationStarted $event): void
                 {
                     MockerState::resetState();
+                    MockerExtension::resetDefaults();
                 }
             },
             new class implements FinishedSubscriber {
                 public function notify(Finished $event): void
                 {
                     MockerState::resetState();
+                    MockerExtension::resetDefaults();
                 }
             },
         );
@@ -73,10 +76,37 @@ final class MockerExtension implements Extension
         $mocksPath = __DIR__ . '/../../runtime/.phpunit.cache/internal-mocker/mocks.php';
         $stubPath = __DIR__ . '/internal-mocker-stubs.php';
 
+        /**
+         * Force regeneration of the namespaced wrappers on every run so a stale cache persisted by a CI runner,
+         * an opcache layer, or a previous local session with a different mock list cannot silently shadow the current
+         * configuration. `Mocker::load()` uses `require_once`, so the very first require in this process binds the
+         * namespaced function symbols; deleting the cached file here ensures that require loads the freshly generated
+         * content rather than an outdated copy.
+         */
+        if (is_file($mocksPath)) {
+            unlink($mocksPath);
+        }
+
         $mocker = new Mocker($mocksPath, $stubPath);
 
         $mocker->load($mocks);
 
         MockerState::saveState();
+    }
+
+    /**
+     * Clears {@see MockerState::$defaults} via reflection between tests.
+     *
+     * `MockerState::resetState()` only restores `$state` to its saved snapshot but leaves the `$defaults` map
+     * (populated via `addCondition(..., default: true)`) untouched. That causes a default set in one test to silently
+     * shadow real function calls in every subsequent test. This helper restores clean isolation.
+     */
+    public static function resetDefaults(): void
+    {
+        $reflection = new ReflectionClass(MockerState::class);
+
+        $property = $reflection->getProperty('defaults');
+
+        $property->setValue(null, []);
     }
 }

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -55,22 +55,19 @@ final class MockerExtension implements Extension
     public static function load(): void
     {
         $mocks = [
-            [
-                'namespace' => 'yii\\scaffold\\Scaffold\\Lock',
-                'name' => 'is_readable',
-            ],
-            [
-                'namespace' => 'yii\\scaffold\\Scaffold\\Modes',
-                'name' => 'file_put_contents',
-            ],
-            [
-                'namespace' => 'yii\\scaffold\\Scaffold',
-                'name' => 'mkdir',
-            ],
-            [
-                'namespace' => 'yii\\scaffold\\Scaffold',
-                'name' => 'is_dir',
-            ],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Lock', 'name' => 'is_readable'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Lock', 'name' => 'file_get_contents'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Lock', 'name' => 'file_put_contents'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Lock', 'name' => 'rename'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Lock', 'name' => 'hash_file'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Modes', 'name' => 'file_put_contents'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Modes', 'name' => 'file_get_contents'],
+            ['namespace' => 'yii\\scaffold\\Scaffold\\Modes', 'name' => 'copy'],
+            ['namespace' => 'yii\\scaffold\\Scaffold', 'name' => 'mkdir'],
+            ['namespace' => 'yii\\scaffold\\Scaffold', 'name' => 'is_dir'],
+            ['namespace' => 'yii\\scaffold\\Manifest', 'name' => 'file_get_contents'],
+            ['namespace' => 'yii\\scaffold\\Commands', 'name' => 'file_get_contents'],
+            ['namespace' => 'yii\\scaffold\\Commands', 'name' => 'file_put_contents'],
         ];
 
         $mocksPath = __DIR__ . '/../../runtime/.phpunit.cache/internal-mocker/mocks.php';

--- a/tests/support/Spies/DiffControllerSpy.php
+++ b/tests/support/Spies/DiffControllerSpy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support\Spies;
+
+use yii\scaffold\Commands\DiffController;
+
+use function strlen;
+
+/**
+ * Test double for {@see DiffController} that buffers `stdout`/`stderr` output into in-memory strings.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class DiffControllerSpy extends DiffController
+{
+    /**
+     * Accumulated `stderr` output.
+     */
+    public string $stderrBuffer = '';
+
+    /**
+     * Accumulated `stdout` output.
+     */
+    public string $stdoutBuffer = '';
+
+    public function stderr($string): int
+    {
+        $this->stderrBuffer .= $string;
+
+        return strlen($string);
+    }
+
+    public function stdout($string): int
+    {
+        $this->stdoutBuffer .= $string;
+
+        return strlen($string);
+    }
+}

--- a/tests/support/Spies/StatusControllerSpy.php
+++ b/tests/support/Spies/StatusControllerSpy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\support\Spies;
+
+use yii\scaffold\Commands\StatusController;
+
+use function strlen;
+
+/**
+ * Test double for {@see StatusController} that buffers `stdout`/`stderr` output into in-memory strings.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class StatusControllerSpy extends StatusController
+{
+    /**
+     * Accumulated `stderr` output.
+     */
+    public string $stderrBuffer = '';
+
+    /**
+     * Accumulated `stdout` output.
+     */
+    public string $stdoutBuffer = '';
+
+    public function stderr($string): int
+    {
+        $this->stderrBuffer .= $string;
+
+        return strlen($string);
+    }
+
+    public function stdout($string): int
+    {
+        $this->stdoutBuffer .= $string;
+
+        return strlen($string);
+    }
+}

--- a/tests/support/internal-mocker-stubs.php
+++ b/tests/support/internal-mocker-stubs.php
@@ -21,5 +21,17 @@ $stubs['file_put_contents'] = [
     'signatureArguments' => 'string $filename, mixed $data, int $flags = 0, $context = null',
     'arguments' => '$filename, $data, $flags, $context',
 ];
+$stubs['file_get_contents'] = [
+    'signatureArguments' => 'string $filename, bool $use_include_path = false, $context = null, int $offset = 0, ?int $length = null',
+    'arguments' => '$filename, $use_include_path, $context, $offset, $length',
+];
+$stubs['rename'] = [
+    'signatureArguments' => 'string $from, string $to, $context = null',
+    'arguments' => '$from, $to, $context',
+];
+$stubs['copy'] = [
+    'signatureArguments' => 'string $from, string $to, $context = null',
+    'arguments' => '$from, $to, $context',
+];
 
 return $stubs;

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -6,10 +6,14 @@ namespace yii\scaffold\tests\unit\Commands;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Xepozz\InternalMocker\MockerState;
 use Yii;
+use yii\console\ExitCode;
 use yii\scaffold\Commands\DiffController;
 use yii\scaffold\Module;
+use yii\scaffold\Scaffold\Lock\LockFile;
 use yii\scaffold\tests\support\ConsoleApplicationTrait;
+use yii\scaffold\tests\support\Spies\DiffControllerSpy;
 
 /**
  * Unit tests for {@see DiffController} diff computation via {@see DiffController::buildDiff()}.
@@ -23,9 +27,229 @@ final class DiffControllerTest extends TestCase
 {
     use ConsoleApplicationTrait;
 
+    public function testActionIndexAnnouncesNoDifferencesWhenFilesAreIdentical(): void
+    {
+        $this->seedStubAndDestination(
+            destination: 'config/params.php',
+            content: "<?php return [];\n",
+        );
+
+        $this->writeLockEntry('config/params.php');
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            'Identical stub and destination must result in a success exit code.',
+        );
+        self::assertStringContainsString(
+            'No differences found.',
+            $spy->stdoutBuffer,
+            "Identical content must produce the explicit 'no differences' message.",
+        );
+    }
+
+    public function testActionIndexEmitsDiffWhenFilesDiffer(): void
+    {
+        $this->seedStub('config/params.php', "stub\n");
+
+        $this->writeDestination('config/params.php', "user\n");
+        $this->writeLockEntry('config/params.php');
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            'A valid diff computation must exit with OK even when the diff is non-empty.',
+        );
+        self::assertStringContainsString(
+            '- stub',
+            $spy->stdoutBuffer,
+            'Lines present only in the stub must be reported as removed in the diff output.',
+        );
+        self::assertStringContainsString(
+            '+ user',
+            $spy->stdoutBuffer,
+            'Lines present only on disk must be reported as added in the diff output.',
+        );
+    }
+
+    public function testActionIndexEmitsWarningWhenLockProviderPathEscapesVendor(): void
+    {
+        $this->seedStub('config/params.php', "stub\n");
+
+        // override providers entry so PathResolver's containment check fails and the warning branch runs.
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/name' => [
+                        'version' => '1.0.0',
+                        'path' => '/etc',
+                    ],
+                ],
+                'files' => [
+                    'config/params.php' => [
+                        'hash' => 'sha256:unused',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/config/params.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $spy = $this->makeSpy();
+
+        $spy->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'resolves outside vendor dir',
+            $spy->stderrBuffer,
+            'A lock-recorded provider path that escapes vendor must raise a visible warning before falling back to '
+            . 'the default vendor-relative path.',
+        );
+    }
+
+    public function testActionIndexReturnsErrorWhenCurrentFileReadFails(): void
+    {
+        $this->seedStubAndDestination('config/params.php', "content\n");
+        $this->writeLockEntry('config/params.php');
+
+        $currentPath = "{$this->tempDir}/config/params.php";
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Commands',
+            'file_get_contents',
+            [$currentPath, false, null, 0, null],
+            false,
+        );
+
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'Inability to read the current on-disk file must surface as a non-OK exit code.',
+        );
+        self::assertStringContainsString(
+            'Could not read current file',
+            $spy->stderrBuffer,
+            'User must see a clear error when the on-disk destination cannot be read.',
+        );
+    }
+
+    public function testActionIndexReturnsErrorWhenFileNotTracked(): void
+    {
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('missing.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'Requesting a diff for a destination absent from the lock must return a non-OK exit code.',
+        );
+        self::assertStringContainsString(
+            'is not tracked in scaffold-lock.json',
+            $spy->stderrBuffer,
+            'User must see a clear error when the requested file is not recorded in the lock.',
+        );
+    }
+
+    public function testActionIndexReturnsErrorWhenLockEntryHasUnsafeDestination(): void
+    {
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/name' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/name',
+                    ],
+                ],
+                'files' => [
+                    '../escape.php' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/escape.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('../escape.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'A lock entry whose destination escapes the project root must be rejected before any file I/O.',
+        );
+        self::assertStringContainsString(
+            'Unsafe lock entry',
+            $spy->stderrBuffer,
+            'The diff command must reuse the PathValidator message so users recognize the failure category.',
+        );
+    }
+
+    public function testActionIndexReturnsErrorWhenStubMissing(): void
+    {
+        /**
+         * Provider path resolves inside vendor (required for the containment check to pass) but the stub file itself is
+         * never created, forcing the "Stub not found" branch.
+         */
+        mkdir("{$this->tempDir}/vendor/pkg/name", 0777, recursive: true);
+
+        $this->writeLockEntry('config/params.php');
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::UNSPECIFIED_ERROR,
+            $exitCode,
+            'A missing stub must surface as an error so broken providers fail loudly.',
+        );
+        self::assertStringContainsString(
+            'Stub not found',
+            $spy->stderrBuffer,
+            'User must see a "Stub not found" error pointing to the missing path.',
+        );
+    }
+
+    public function testActionIndexShowsFullStubAsAddedWhenDestinationIsAbsent(): void
+    {
+        $this->seedStub('config/params.php', "line1\nline2\n");
+
+        $this->writeLockEntry('config/params.php');
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex('config/params.php');
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            'Diffing a tracked destination that has been deleted must still succeed.',
+        );
+        self::assertStringContainsString(
+            '- line1',
+            $spy->stdoutBuffer,
+            'When the destination is absent, every stub line must appear as a removed line in the diff.',
+        );
+    }
+
     public function testBuildDiffExactOutputFormat(): void
     {
-        // Trailing newlines on every line force Differ to emit lines ending with `\n`, so rtrim is observable.
+        // trailing newlines on every line force Differ to emit lines ending with `\n`, so rtrim is observable.
         $diff = $this->makeController()->buildDiff("a\nb\n", "a\nc\n");
 
         self::assertSame(
@@ -140,5 +364,58 @@ final class DiffControllerTest extends TestCase
         assert($module instanceof Module);
 
         return new DiffController('diff', $module);
+    }
+
+    private function makeSpy(): DiffControllerSpy
+    {
+        $module = Yii::$app->getModule('scaffold');
+
+        assert($module instanceof Module);
+
+        return new DiffControllerSpy('diff', $module);
+    }
+
+    private function seedStub(string $destination, string $content, string $providerName = 'pkg/name'): void
+    {
+        $stubPath = "{$this->tempDir}/vendor/{$providerName}/stubs/{$destination}";
+
+        mkdir(dirname($stubPath), 0777, recursive: true);
+
+        file_put_contents($stubPath, $content);
+    }
+
+    private function seedStubAndDestination(string $destination, string $content): void
+    {
+        $this->seedStub($destination, $content);
+        $this->writeDestination($destination, $content);
+    }
+
+    private function writeDestination(string $destination, string $content): void
+    {
+        $path = "{$this->tempDir}/{$destination}";
+
+        mkdir(dirname($path), 0777, recursive: true);
+
+        file_put_contents($path, $content);
+    }
+
+    private function writeLockEntry(string $destination, string $providerName = 'pkg/name'): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $data = $lock->read();
+
+        $data['providers'][$providerName] = [
+            'version' => '1.0.0',
+            'path' => "vendor/{$providerName}",
+        ];
+        $data['files'][$destination] = [
+            'hash' => 'sha256:unused',
+            'provider' => $providerName,
+            'source' => "stubs/{$destination}",
+            'mode' => 'replace',
+        ];
+
+        $lock->write($data);
     }
 }

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -231,7 +231,7 @@ final class DiffControllerTest extends TestCase
         );
     }
 
-    public function testActionIndexShowsFullStubAsAddedWhenDestinationIsAbsent(): void
+    public function testActionIndexShowsFullStubAsRemovedWhenDestinationIsAbsent(): void
     {
         $this->seedStub('config/params.php', "line1\nline2\n");
 

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -12,7 +12,6 @@ use yii\console\ExitCode;
 use yii\scaffold\Commands\DiffController;
 use yii\scaffold\Module;
 use yii\scaffold\Scaffold\Lock\LockFile;
-use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\ConsoleApplicationTrait;
 use yii\scaffold\tests\support\Spies\DiffControllerSpy;
 
@@ -122,16 +121,16 @@ final class DiffControllerTest extends TestCase
         $this->writeLockEntry('config/params.php');
 
         /**
-         * `Yii::$app->basePath` was realpath-canonicalized during setup; the mocker condition must use that exact value
-         * (not `$this->tempDir`, which can still carry mixed separators on Windows).
+         * `default: true` makes the mocker return `false` for every call to `file_get_contents` in this namespace,
+         * regardless of the arguments. This keeps the test robust to path-separator differences between Linux and
+         * Windows (mixed backslash/forward-slash paths would otherwise break argument matching).
          */
-        $currentPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
-
         MockerState::addCondition(
             'yii\\scaffold\\Commands',
             'file_get_contents',
-            [$currentPath, false, null, 0, null],
+            [],
             false,
+            default: true,
         );
 
         $spy = $this->makeSpy();

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -118,9 +118,14 @@ final class DiffControllerTest extends TestCase
     public function testActionIndexReturnsErrorWhenCurrentFileReadFails(): void
     {
         $this->seedStubAndDestination('config/params.php', "content\n");
+
         $this->writeLockEntry('config/params.php');
 
-        $currentPath = PathResolver::destination($this->tempDir, 'config/params.php');
+        /**
+         * `Yii::$app->basePath` was realpath-canonicalized during setup; the mocker condition must use that exact value
+         * (not `$this->tempDir`, which can still carry mixed separators on Windows).
+         */
+        $currentPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
 
         MockerState::addCondition(
             'yii\\scaffold\\Commands',

--- a/tests/unit/Commands/DiffControllerTest.php
+++ b/tests/unit/Commands/DiffControllerTest.php
@@ -12,6 +12,7 @@ use yii\console\ExitCode;
 use yii\scaffold\Commands\DiffController;
 use yii\scaffold\Module;
 use yii\scaffold\Scaffold\Lock\LockFile;
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\ConsoleApplicationTrait;
 use yii\scaffold\tests\support\Spies\DiffControllerSpy;
 
@@ -119,7 +120,7 @@ final class DiffControllerTest extends TestCase
         $this->seedStubAndDestination('config/params.php', "content\n");
         $this->writeLockEntry('config/params.php');
 
-        $currentPath = "{$this->tempDir}/config/params.php";
+        $currentPath = PathResolver::destination($this->tempDir, 'config/params.php');
 
         MockerState::addCondition(
             'yii\\scaffold\\Commands',

--- a/tests/unit/Commands/EjectControllerTest.php
+++ b/tests/unit/Commands/EjectControllerTest.php
@@ -120,6 +120,17 @@ final class EjectControllerTest extends TestCase
         );
     }
 
+    public function testOptionsExposesYesFlag(): void
+    {
+        $options = $this->makeController(yes: false)->options('index');
+
+        self::assertContains(
+            'yes',
+            $options,
+            "'eject' command must expose the '--yes' flag in its options() list so Yii's console router accepts it.",
+        );
+    }
+
     public function testReturnsErrorWhenFileNotTracked(): void
     {
         (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -6,6 +6,7 @@ namespace yii\scaffold\tests\unit\Commands;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Xepozz\InternalMocker\MockerState;
 use Yii;
 use yii\console\ExitCode;
 use yii\scaffold\Module;
@@ -28,10 +29,10 @@ final class ReapplyControllerTest extends TestCase
     public function testAppendAndPrependModesCannotBeReapplied(): void
     {
         $this->seedProviderStub('stubs/.gitignore', "/runtime/\n");
+
         $this->writeLockEntry('.gitignore', "/runtime/\n", 'append');
         $this->seedProviderStub('stubs/.env', "APP_ENV=dev\n");
         $this->writeLockEntry('.env', "APP_ENV=dev\n", 'prepend');
-
         $controller = $this->makeController(force: false);
 
         $exitCode = $controller->actionIndex();
@@ -53,6 +54,76 @@ final class ReapplyControllerTest extends TestCase
         );
     }
 
+    public function testEmitsWarningWhenProviderPathEscapesVendor(): void
+    {
+        /**
+         * Lock records a provider path that resolves outside vendor; PathResolver returns a warning that must reach
+         * stderr before scaffold falls back to the default vendor-relative path.
+         */
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [
+                    'pkg/name' => [
+                        'version' => '1.0.0',
+                        'path' => '/etc',
+                    ],
+                ],
+                'files' => [
+                    'config/params.php' => [
+                        'hash' => 'sha256:' . hash('sha256', "stub\n"),
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/config/params.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $this->seedProviderStub('stubs/config/params.php', "stub\n");
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'resolves outside vendor dir',
+            $controller->stderrBuffer,
+            'A provider path that escapes vendor must emit a visible warning before the fallback resolution.',
+        );
+    }
+
+    public function testEnsureDirectoryFailureIsReportedAsError(): void
+    {
+        $stub = "stub\n";
+
+        $this->seedProviderStub('stubs/nested/deep.php', $stub);
+        $this->writeLockEntry('nested/deep.php', $stub, 'replace');
+
+        $parentDir = "{$this->tempDir}/nested";
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'is_dir',
+            [$parentDir],
+            false,
+        );
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold',
+            'mkdir',
+            [$parentDir, 0777, true, null],
+            false,
+        );
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex('nested/deep.php');
+
+        self::assertStringContainsString(
+            'Could not create directory',
+            $controller->stderrBuffer,
+            'ensureDirectory exceptions must be surfaced as a skip-with-reason instead of crashing the reapply loop.',
+        );
+    }
+
     public function testForceOverwritesUserModifiedFileAndUpdatesLockHash(): void
     {
         $stubContent = "stub v2\n";
@@ -62,6 +133,7 @@ final class ReapplyControllerTest extends TestCase
         $this->writeLockEntry('config/params.php', "stub v1\n", 'replace');
 
         $destination = "{$this->tempDir}/config/params.php";
+
         mkdir(dirname($destination), 0777, recursive: true);
         file_put_contents($destination, $userContent);
 
@@ -85,9 +157,107 @@ final class ReapplyControllerTest extends TestCase
         );
     }
 
+    public function testHashFailureBeforeWriteIsReported(): void
+    {
+        $stub = "stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'replace');
+
+        $destPath = "{$this->tempDir}/config/params.php";
+
+        mkdir(dirname($destPath), 0777, recursive: true);
+        file_put_contents($destPath, 'existing');
+
+        // force the pre-write hash check to explode by making `is_readable` report false on the destination.
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'is_readable',
+            [$destPath],
+            false,
+        );
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'Could not hash',
+            $controller->stderrBuffer,
+            'A failure to hash the destination before write must be surfaced as a skip-with-reason message.',
+        );
+    }
+
+    public function testMissingStubIsReportedAsError(): void
+    {
+        // provider directory exists (containment check passes) but the stub file itself is never created.
+        mkdir("{$this->tempDir}/vendor/pkg/name", 0777, recursive: true);
+
+        $this->writeLockEntry('config/params.php', "stub\n", 'replace');
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'Stub not found',
+            $controller->stderrBuffer,
+            'A missing stub must emit a clear "Stub not found" error so broken providers fail loudly.',
+        );
+    }
+
+    public function testOptionsExposesForceAndProviderFlags(): void
+    {
+        $options = $this->makeController(force: false)->options('index');
+
+        self::assertContains(
+            'force',
+            $options,
+            "'reapply' command must expose the '--force' flag in its options() list so Yii's console router accepts it.",
+        );
+        self::assertContains(
+            'provider',
+            $options,
+            "'reapply' command must expose the '--provider' flag in its options() list so Yii's console router accepts "
+            . 'it.',
+        );
+    }
+
+    public function testPostWriteHashFailureSkipsLockUpdate(): void
+    {
+        $stub = "stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'replace');
+
+        $destPath = "{$this->tempDir}/config/params.php";
+
+        /**
+         * `is_readable` reports false ONLY for the destination, making the post-write hash fail. Does not interfere
+         * with the stub path.
+         */
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'is_readable',
+            [$destPath],
+            false,
+        );
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'Could not hash written file',
+            $controller->stderrBuffer,
+            'A post-write hash failure must be reported without crashing the whole reapply loop.',
+        );
+    }
+
     public function testPreserveModeIsSkippedWithoutForce(): void
     {
         $this->seedProviderStub('stubs/config/params.php', "stub\n");
+
         $this->writeLockEntry('config/params.php', "stub\n", 'preserve');
 
         $destination = "{$this->tempDir}/config/params.php";
@@ -108,6 +278,49 @@ final class ReapplyControllerTest extends TestCase
             'uses mode "preserve". Use --force to overwrite',
             $controller->stdoutBuffer,
             "Preserve-mode skip must guide the user toward the '--force' escape hatch.",
+        );
+    }
+
+    public function testPreserveModeRewritesWhenDestinationIsMissing(): void
+    {
+        /**
+         * Preserve mode only skips when the destination ALREADY exists. When the destination is gone (user deleted it),
+         * reapply must re-create it from the stub — this exercises the "preserve + file absent" branch.
+         */
+        $stub = "initial stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'preserve');
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertFileExists(
+            "{$this->tempDir}/config/params.php",
+            'Preserve mode must re-materialize the destination when the file is missing on disk.',
+        );
+    }
+
+    public function testPreserveModeWithForceOverwritesDestination(): void
+    {
+        $stub = "fresh stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'preserve');
+
+        $destination = "{$this->tempDir}/config/params.php";
+        mkdir(dirname($destination), 0777, recursive: true);
+        file_put_contents($destination, "user kept\n");
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertSame(
+            $stub,
+            file_get_contents($destination),
+            "'--force' must override preserve-mode protection and rewrite the destination with the current stub.",
         );
     }
 
@@ -159,6 +372,68 @@ final class ReapplyControllerTest extends TestCase
         );
     }
 
+    public function testReappliesSpecificFileWhenFilterMatches(): void
+    {
+        $stub = "stub A\n";
+
+        $this->seedProviderStub('stubs/a.txt', $stub);
+        $this->seedProviderStub('stubs/b.txt', 'stub B');
+        $this->writeLockEntry('a.txt', 'old A', 'replace');
+        $this->writeLockEntry('b.txt', 'old B', 'replace');
+
+        $controller = $this->makeController(force: true);
+
+        // passing a specific file path narrows the reapply to that single destination.
+        $controller->actionIndex('a.txt');
+
+        self::assertFileExists(
+            "{$this->tempDir}/a.txt",
+            'The targeted file must be reapplied.',
+        );
+        self::assertFileDoesNotExist(
+            "{$this->tempDir}/b.txt",
+            'Files outside the file filter must not be touched.',
+        );
+    }
+
+    public function testRejectsLockEntryWithUnsafeDestination(): void
+    {
+        $lock = new LockFile($this->tempDir);
+
+        $lock->write(
+            [
+                'providers' => [
+                    'pkg/name' => [
+                        'version' => '1.0.0',
+                        'path' => 'vendor/pkg/name',
+                    ],
+                ],
+                'files' => [
+                    // path traversal in the recorded destination triggers the PathValidator reject.
+                    '../escape.php' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/escape.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        mkdir("{$this->tempDir}/vendor/pkg/name/stubs", 0777, recursive: true);
+        file_put_contents("{$this->tempDir}/vendor/pkg/name/stubs/escape.php", 'content');
+
+        $controller = $this->makeController(force: false);
+
+        $controller->actionIndex();
+
+        self::assertStringContainsString(
+            'Unsafe lock entry',
+            $controller->stderrBuffer,
+            'Unsafe destinations recorded in the lock must be rejected with a clear error message before any I/O.',
+        );
+    }
+
     public function testReturnsErrorWhenFilterMatchesNothing(): void
     {
         $this->writeLockEntry('config/params.php', "stub\n", 'replace');
@@ -182,6 +457,7 @@ final class ReapplyControllerTest extends TestCase
     public function testSkipsUserModifiedFileWithoutForce(): void
     {
         $this->seedProviderStub('stubs/config/params.php', "stub v1\n");
+
         $this->writeLockEntry('config/params.php', "stub v1\n", 'replace');
 
         $destination = "{$this->tempDir}/config/params.php";
@@ -202,6 +478,60 @@ final class ReapplyControllerTest extends TestCase
             'is user-modified. Use --force to overwrite',
             $controller->stdoutBuffer,
             "User-modified skip must name the '--force' flag as the escape hatch.",
+        );
+    }
+
+    public function testStubReadFailureIsReportedAsError(): void
+    {
+        $stub = "stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'replace');
+
+        $stubPath = "{$this->tempDir}/vendor/pkg/name/stubs/config/params.php";
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Commands',
+            'file_get_contents',
+            [$stubPath, false, null, 0, null],
+            false,
+        );
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'Could not read stub',
+            $controller->stderrBuffer,
+            "An unreadable stub must emit a 'Could not read stub' skip message rather than crashing the command.",
+        );
+    }
+
+    public function testWriteFailureIsReportedAsError(): void
+    {
+        $stub = "stub\n";
+
+        $this->seedProviderStub('stubs/config/params.php', $stub);
+        $this->writeLockEntry('config/params.php', $stub, 'replace');
+
+        $destPath = "{$this->tempDir}/config/params.php";
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Commands',
+            'file_put_contents',
+            [$destPath, $stub, 0, null],
+            false,
+        );
+
+        $controller = $this->makeController(force: true);
+
+        $controller->actionIndex('config/params.php');
+
+        self::assertStringContainsString(
+            'Could not write',
+            $controller->stderrBuffer,
+            'A failed destination write must be reported as a skip-with-reason without aborting subsequent entries.',
         );
     }
 

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -11,6 +11,7 @@ use Yii;
 use yii\console\ExitCode;
 use yii\scaffold\Module;
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\ConsoleApplicationTrait;
 use yii\scaffold\tests\support\Spies\ReapplyControllerSpy;
 
@@ -98,7 +99,10 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/nested/deep.php', $stub);
         $this->writeLockEntry('nested/deep.php', $stub, 'replace');
 
-        $parentDir = "{$this->tempDir}/nested";
+        // parent directory must match exactly what `PathResolver::ensureDirectory()` computes internally, otherwise
+        // the mocker won't intercept and the real mkdir succeeds.
+        $destPath = PathResolver::destination($this->tempDir, 'nested/deep.php');
+        $parentDir = dirname($destPath);
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold',
@@ -164,7 +168,7 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = "{$this->tempDir}/config/params.php";
+        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
 
         mkdir(dirname($destPath), 0777, recursive: true);
         file_put_contents($destPath, 'existing');
@@ -230,7 +234,7 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = "{$this->tempDir}/config/params.php";
+        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
 
         /**
          * `is_readable` reports false ONLY for the destination, making the post-write hash fail. Does not interfere
@@ -488,7 +492,13 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $stubPath = "{$this->tempDir}/vendor/pkg/name/stubs/config/params.php";
+        /**
+         * resolveProviderRoot realpaths the recorded path; match the exact absolute stub path the controller passes to
+         * `file_get_contents`, including DIRECTORY_SEPARATOR on Windows.
+         */
+        $providerRoot = (string) realpath("{$this->tempDir}/vendor/pkg/name");
+
+        $stubPath = PathResolver::source($providerRoot, 'stubs/config/params.php');
 
         MockerState::addCondition(
             'yii\\scaffold\\Commands',
@@ -515,7 +525,7 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = "{$this->tempDir}/config/params.php";
+        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
 
         MockerState::addCondition(
             'yii\\scaffold\\Commands',

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -100,30 +100,12 @@ final class ReapplyControllerTest extends TestCase
         $this->writeLockEntry('nested/deep.php', $stub, 'replace');
 
         /**
-         * projectRoot inside the controller is `Yii::$app->basePath`, already realpath-canonicalized (backslashes-only
-         * on Windows). Use it here so the mocker condition matches the real mkdir call.
+         * Use `default: true` to intercept all `is_dir` and `mkdir` calls in the Scaffold namespace regardless of
+         * platform path-separator differences; the test only cares that ensureDirectory explodes and the controller
+         * surfaces a skip-with-reason.
          */
-        $destPath = PathResolver::destination(Yii::$app->basePath, 'nested/deep.php');
-
-        $parentDir = dirname($destPath);
-
-        MockerState::addCondition(
-            'yii\\scaffold\\Scaffold',
-            'is_dir',
-            [$parentDir],
-            false,
-        );
-        MockerState::addCondition(
-            'yii\\scaffold\\Scaffold',
-            'mkdir',
-            [
-                $parentDir,
-                0777,
-                true,
-                null,
-            ],
-            false,
-        );
+        MockerState::addCondition('yii\\scaffold\\Scaffold', 'is_dir', [], false, default: true);
+        MockerState::addCondition('yii\\scaffold\\Scaffold', 'mkdir', [], false, default: true);
 
         $controller = $this->makeController(force: true);
 
@@ -181,12 +163,16 @@ final class ReapplyControllerTest extends TestCase
         mkdir(dirname($destPath), 0777, recursive: true);
         file_put_contents($destPath, 'existing');
 
-        // force the pre-write hash check to explode by making `is_readable` report false on the destination.
+        /**
+         * default-mock `is_readable` so every lookup returns false and the pre-write hash throws, independent of how
+         * the path is spelled on disk (matters on Windows where separators can differ).
+         */
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'is_readable',
-            [$destPath],
+            [],
             false,
+            default: true,
         );
 
         $controller = $this->makeController(force: false);
@@ -242,17 +228,16 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
-
         /**
-         * `is_readable` reports false ONLY for the destination, making the post-write hash fail. Does not interfere
-         * with the stub path.
+         * default-mock `is_readable` to always report false; both the pre-write and post-write hash checks fail, and
+         * the `--force` flag bypasses the pre-write one, so the test specifically exercises the post-write branch.
          */
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'is_readable',
-            [$destPath],
+            [],
             false,
+            default: true,
         );
 
         $controller = $this->makeController(force: true);
@@ -297,7 +282,7 @@ final class ReapplyControllerTest extends TestCase
     {
         /**
          * Preserve mode only skips when the destination ALREADY exists. When the destination is gone (user deleted it),
-         * reapply must re-create it from the stub — this exercises the "preserve + file absent" branch.
+         * reapply must re-create it from the stub this exercises the "preserve + file absent" branch.
          */
         $stub = "initial stub\n";
 
@@ -502,18 +487,15 @@ final class ReapplyControllerTest extends TestCase
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
         /**
-         * resolveProviderRoot realpaths the recorded path; match the exact absolute stub path the controller passes to
-         * `file_get_contents`, including DIRECTORY_SEPARATOR on Windows.
+         * default-mock `file_get_contents` to always return false the only call in `Commands` is the stub read, so
+         * this deterministically forces the "Could not read stub" branch on any platform.
          */
-        $providerRoot = (string) realpath("{$this->tempDir}/vendor/pkg/name");
-
-        $stubPath = PathResolver::source($providerRoot, 'stubs/config/params.php');
-
         MockerState::addCondition(
             'yii\\scaffold\\Commands',
             'file_get_contents',
-            [$stubPath, false, null, 0, null],
+            [],
             false,
+            default: true,
         );
 
         $controller = $this->makeController(force: true);
@@ -534,18 +516,13 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
-
+        // default-mock `file_put_contents` to always return false; controller must surface "Could not write" error.
         MockerState::addCondition(
             'yii\\scaffold\\Commands',
             'file_put_contents',
-            [
-                $destPath,
-                $stub,
-                0,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $controller = $this->makeController(force: true);

--- a/tests/unit/Commands/ReapplyControllerTest.php
+++ b/tests/unit/Commands/ReapplyControllerTest.php
@@ -99,9 +99,12 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/nested/deep.php', $stub);
         $this->writeLockEntry('nested/deep.php', $stub, 'replace');
 
-        // parent directory must match exactly what `PathResolver::ensureDirectory()` computes internally, otherwise
-        // the mocker won't intercept and the real mkdir succeeds.
-        $destPath = PathResolver::destination($this->tempDir, 'nested/deep.php');
+        /**
+         * projectRoot inside the controller is `Yii::$app->basePath`, already realpath-canonicalized (backslashes-only
+         * on Windows). Use it here so the mocker condition matches the real mkdir call.
+         */
+        $destPath = PathResolver::destination(Yii::$app->basePath, 'nested/deep.php');
+
         $parentDir = dirname($destPath);
 
         MockerState::addCondition(
@@ -113,7 +116,12 @@ final class ReapplyControllerTest extends TestCase
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold',
             'mkdir',
-            [$parentDir, 0777, true, null],
+            [
+                $parentDir,
+                0777,
+                true,
+                null,
+            ],
             false,
         );
 
@@ -168,7 +176,7 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
+        $destPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
 
         mkdir(dirname($destPath), 0777, recursive: true);
         file_put_contents($destPath, 'existing');
@@ -234,7 +242,7 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
+        $destPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
 
         /**
          * `is_readable` reports false ONLY for the destination, making the post-write hash fail. Does not interfere
@@ -314,6 +322,7 @@ final class ReapplyControllerTest extends TestCase
         $this->writeLockEntry('config/params.php', $stub, 'preserve');
 
         $destination = "{$this->tempDir}/config/params.php";
+
         mkdir(dirname($destination), 0777, recursive: true);
         file_put_contents($destination, "user kept\n");
 
@@ -525,12 +534,17 @@ final class ReapplyControllerTest extends TestCase
         $this->seedProviderStub('stubs/config/params.php', $stub);
         $this->writeLockEntry('config/params.php', $stub, 'replace');
 
-        $destPath = PathResolver::destination($this->tempDir, 'config/params.php');
+        $destPath = PathResolver::destination(Yii::$app->basePath, 'config/params.php');
 
         MockerState::addCondition(
             'yii\\scaffold\\Commands',
             'file_put_contents',
-            [$destPath, $stub, 0, null],
+            [
+                $destPath,
+                $stub,
+                0,
+                null,
+            ],
             false,
         );
 

--- a/tests/unit/Commands/StatusControllerTest.php
+++ b/tests/unit/Commands/StatusControllerTest.php
@@ -6,6 +6,7 @@ namespace yii\scaffold\tests\unit\Commands;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Xepozz\InternalMocker\MockerState;
 use Yii;
 use yii\console\ExitCode;
 use yii\scaffold\Commands\StatusController;
@@ -137,18 +138,9 @@ final class StatusControllerTest extends TestCase
 
     public function testGetStatusesMarksEntryAsErrorWhenHashThrows(): void
     {
-        if (DIRECTORY_SEPARATOR === '\\') {
-            self::markTestSkipped('POSIX chmod is required to make a file unreadable; Windows lacks an equivalent.');
-        }
-
-        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
-            self::markTestSkipped("Test cannot run as root because 'chmod 0000' does not block root reads.");
-        }
-
         $filePath = "{$this->tempDir}/unreadable.txt";
 
         file_put_contents($filePath, 'content');
-        chmod($filePath, 0000);
 
         (new LockFile($this->tempDir))->write(
             [
@@ -164,17 +156,26 @@ final class StatusControllerTest extends TestCase
             ],
         );
 
-        try {
-            $statuses = $this->makeController()->getStatuses($this->tempDir);
+        /**
+         * force `is_readable` to return false inside the Lock namespace, making `Hasher::hash()` throw. The controller
+         * must catch it and surface status 'error'. `default: true` keeps the test platform-agnostic no `chmod` or
+         * uid gates are needed, so it runs on Windows, macOS, and as root.
+         */
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'is_readable',
+            [],
+            false,
+            default: true,
+        );
 
-            self::assertSame(
-                'error',
-                $statuses['unreadable.txt']['status'] ?? null,
-                "When hash throws because the file is unreadable, the destination must surface with status 'error'.",
-            );
-        } finally {
-            chmod($filePath, 0644);
-        }
+        $statuses = $this->makeController()->getStatuses($this->tempDir);
+
+        self::assertSame(
+            'error',
+            $statuses['unreadable.txt']['status'] ?? null,
+            "When 'hash' throws because the file is unreadable, the destination must surface with status 'error'.",
+        );
     }
 
     public function testGetStatusesReturnsAllEntriesPreservingOrder(): void

--- a/tests/unit/Commands/StatusControllerTest.php
+++ b/tests/unit/Commands/StatusControllerTest.php
@@ -7,10 +7,12 @@ namespace yii\scaffold\tests\unit\Commands;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Yii;
+use yii\console\ExitCode;
 use yii\scaffold\Commands\StatusController;
 use yii\scaffold\Module;
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
 use yii\scaffold\tests\support\ConsoleApplicationTrait;
+use yii\scaffold\tests\support\Spies\StatusControllerSpy;
 
 /**
  * Unit tests for {@see StatusController} status computation via {@see StatusController::getStatuses()}.
@@ -23,6 +25,157 @@ use yii\scaffold\tests\support\ConsoleApplicationTrait;
 final class StatusControllerTest extends TestCase
 {
     use ConsoleApplicationTrait;
+
+    public function testActionIndexPrintsEmptyMessageWhenNoFilesTracked(): void
+    {
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex();
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            'Empty-lock status must still return a success exit code.',
+        );
+        self::assertStringContainsString(
+            'No files tracked in scaffold-lock.json',
+            $spy->stdoutBuffer,
+            'Empty-lock case must emit the user-facing no-files message instead of a blank table.',
+        );
+    }
+
+    public function testActionIndexPrintsHeaderAndRowsForTrackedFiles(): void
+    {
+        $filePath = "{$this->tempDir}/output.txt";
+
+        file_put_contents($filePath, 'synced content');
+
+        $hash = (new Hasher())->hash($filePath);
+
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [],
+                'files' => [
+                    'output.txt' => [
+                        'hash' => $hash,
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/output.txt',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $spy = $this->makeSpy();
+
+        $exitCode = $spy->actionIndex();
+
+        self::assertSame(
+            ExitCode::OK,
+            $exitCode,
+            "Status command with tracked entries must return 'ExitCode::OK'.",
+        );
+        self::assertStringContainsString(
+            'File',
+            $spy->stdoutBuffer,
+            "Status output must include a 'File' column header.",
+        );
+        self::assertStringContainsString(
+            'Provider',
+            $spy->stdoutBuffer,
+            "Status output must include a 'Provider' column header.",
+        );
+        self::assertStringContainsString(
+            'Mode',
+            $spy->stdoutBuffer,
+            "Status output must include a 'Mode' column header.",
+        );
+        self::assertStringContainsString(
+            'Status',
+            $spy->stdoutBuffer,
+            "Status output must include a 'Status' column header.",
+        );
+        self::assertStringContainsString(
+            'output.txt',
+            $spy->stdoutBuffer,
+            'Tracked destination must appear in the output row.',
+        );
+        self::assertStringContainsString(
+            'synced',
+            $spy->stdoutBuffer,
+            "Matching-hash entries must appear with status 'synced'.",
+        );
+    }
+
+    public function testGetStatusesMarksEntryAsErrorWhenDestinationIsUnsafe(): void
+    {
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [],
+                'files' => [
+                    '../escape.php' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/escape.php',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        $statuses = $this->makeController()->getStatuses($this->tempDir);
+
+        self::assertSame(
+            'error',
+            $statuses['../escape.php']['status'] ?? null,
+            "Lock entries whose destination fails path validation must surface status 'error' rather than masking the "
+            . 'problem.',
+        );
+    }
+
+    public function testGetStatusesMarksEntryAsErrorWhenHashThrows(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX chmod is required to make a file unreadable; Windows lacks an equivalent.');
+        }
+
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            self::markTestSkipped("Test cannot run as root because 'chmod 0000' does not block root reads.");
+        }
+
+        $filePath = "{$this->tempDir}/unreadable.txt";
+
+        file_put_contents($filePath, 'content');
+        chmod($filePath, 0000);
+
+        (new LockFile($this->tempDir))->write(
+            [
+                'providers' => [],
+                'files' => [
+                    'unreadable.txt' => [
+                        'hash' => 'sha256:abc',
+                        'provider' => 'pkg/name',
+                        'source' => 'stubs/unreadable.txt',
+                        'mode' => 'replace',
+                    ],
+                ],
+            ],
+        );
+
+        try {
+            $statuses = $this->makeController()->getStatuses($this->tempDir);
+
+            self::assertSame(
+                'error',
+                $statuses['unreadable.txt']['status'] ?? null,
+                "When hash throws because the file is unreadable, the destination must surface with status 'error'.",
+            );
+        } finally {
+            chmod($filePath, 0644);
+        }
+    }
 
     public function testGetStatusesReturnsAllEntriesPreservingOrder(): void
     {
@@ -221,5 +374,14 @@ final class StatusControllerTest extends TestCase
         assert($module instanceof Module);
 
         return new StatusController('status', $module);
+    }
+
+    private function makeSpy(): StatusControllerSpy
+    {
+        $module = Yii::$app->getModule('scaffold');
+
+        assert($module instanceof Module);
+
+        return new StatusControllerSpy('status', $module);
     }
 }

--- a/tests/unit/EventSubscriberTest.php
+++ b/tests/unit/EventSubscriberTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\unit;
 
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\BufferIO;
+use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use yii\scaffold\EventSubscriber;
 
 /**
@@ -43,5 +48,40 @@ final class EventSubscriberTest extends TestCase
             EventSubscriber::getSubscribedEvents(),
             'Event subscriber does not register for the post-update-cmd event.',
         );
+    }
+
+    public function testRunScaffoldAbortsWhenVendorDirIsEmpty(): void
+    {
+        $io = new BufferIO();
+
+        $config = self::createStub(Config::class);
+
+        $config->method('get')->willReturn('');
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getConfig')->willReturn($config);
+
+        $this->resetFlag();
+
+        (new EventSubscriber())->onPostInstall(
+            new ScriptEvent(ScriptEvents::POST_INSTALL_CMD, $composer, $io, true),
+        );
+
+        self::assertStringContainsString(
+            'Unable to resolve vendor-dir',
+            $io->getOutput(),
+            'An empty vendor-dir must short-circuit the scaffold run with a clear error on stderr.',
+        );
+    }
+
+    /**
+     * Resets the private static flag so each test runs with a clean lifecycle slate.
+     */
+    private function resetFlag(): void
+    {
+        $reflection = new ReflectionClass(EventSubscriber::class);
+        $property = $reflection->getProperty('installScaffoldRan');
+        $property->setValue(null, false);
     }
 }

--- a/tests/unit/EventSubscriberTest.php
+++ b/tests/unit/EventSubscriberTest.php
@@ -62,8 +62,6 @@ final class EventSubscriberTest extends TestCase
 
         $composer->method('getConfig')->willReturn($config);
 
-        $this->resetFlag();
-
         (new EventSubscriber())->onPostInstall(
             new ScriptEvent(ScriptEvents::POST_INSTALL_CMD, $composer, $io, true),
         );
@@ -76,12 +74,15 @@ final class EventSubscriberTest extends TestCase
     }
 
     /**
-     * Resets the private static flag so each test runs with a clean lifecycle slate.
+     * Resets {@see EventSubscriber::$installScaffoldRan} so each test starts with a clean lifecycle slate; keeps the
+     * suite order-independent regardless of which event handlers previous tests invoked.
      */
-    private function resetFlag(): void
+    protected function setUp(): void
     {
         $reflection = new ReflectionClass(EventSubscriber::class);
+
         $property = $reflection->getProperty('installScaffoldRan');
+
         $property->setValue(null, false);
     }
 }

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -9,6 +9,7 @@ use JsonException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\{FileMapping, ManifestLoader, ManifestSchema};
 
 /**
@@ -114,6 +115,39 @@ final class ManifestLoaderTest extends TestCase
             $first->providerPath,
             "Expected providerPath to be '{$providerPath}'",
         );
+    }
+
+    public function testExternalManifestWhenFileGetContentsFailsThrows(): void
+    {
+        $providerPath = sys_get_temp_dir() . '/scaffold-unreadable-manifest-' . uniqid();
+
+        mkdir($providerPath, 0777, recursive: true);
+
+        $manifestPath = "{$providerPath}/scaffold.json";
+
+        file_put_contents($manifestPath, '{}');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Manifest',
+            'file_get_contents',
+            [$manifestPath, false, null, 0, null],
+            false,
+        );
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
+        $package->method('getName')->willReturn('yii2-extensions/bad');
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('could not read manifest file');
+
+            (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
+        } finally {
+            @unlink($manifestPath);
+            @rmdir($providerPath);
+        }
     }
 
     public function testExternalManifestWithBackslashAbsolutePathThrows(): void
@@ -242,6 +276,62 @@ final class ManifestLoaderTest extends TestCase
         $this->expectExceptionMessage('not found');
 
         (new ManifestLoader(new ManifestSchema()))->load($package, '/nonexistent/path');
+    }
+
+    public function testExternalManifestWithNonObjectJsonThrows(): void
+    {
+        $providerPath = sys_get_temp_dir() . '/scaffold-non-object-manifest-' . uniqid();
+
+        if (!mkdir($providerPath, 0777, recursive: true)) {
+            self::fail("Could not create fixture directory '{$providerPath}'.");
+        }
+
+        // write a JSON payload that decodes to a scalar, not an object.
+        file_put_contents("{$providerPath}/scaffold.json", '"just a string"');
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(
+                [
+                    'scaffold' => ['manifest' => 'scaffold.json'],
+                ],
+            );
+        $package
+            ->method('getName')
+            ->willReturn('yii2-extensions/bad');
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('must decode to an object');
+
+            (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
+        } finally {
+            @unlink("{$providerPath}/scaffold.json");
+            @rmdir($providerPath);
+        }
+    }
+
+    public function testExternalManifestWithTraversalPathThrows(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(
+                [
+                    'scaffold' => ['manifest' => '../escape.json'],
+                ],
+            );
+        $package
+            ->method('getName')
+            ->willReturn('yii2-extensions/bad');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a relative path inside the provider root');
+
+        (new ManifestLoader(new ManifestSchema()))->load($package, '/vendor/yii2-extensions/bad');
     }
 
     public function testInlineFileMappingCarriesProviderNameAndPath(): void

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\{FileMapping, ManifestLoader, ManifestSchema};
+use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
  * Unit tests for {@see ManifestLoader} inline and external manifest loading.
@@ -22,6 +23,8 @@ use yii\scaffold\Manifest\{FileMapping, ManifestLoader, ManifestSchema};
 #[Group('manifest')]
 final class ManifestLoaderTest extends TestCase
 {
+    use TempDirectoryTrait;
+
     public function testAllFileMappingsAreInstancesOfFileMapping(): void
     {
         $package = self::createStub(PackageInterface::class);
@@ -119,19 +122,20 @@ final class ManifestLoaderTest extends TestCase
 
     public function testExternalManifestWhenFileGetContentsFailsThrows(): void
     {
-        $providerPath = sys_get_temp_dir() . '/scaffold-unreadable-manifest-' . uniqid();
-
-        mkdir($providerPath, 0777, recursive: true);
-
-        $manifestPath = "{$providerPath}/scaffold.json";
+        $manifestPath = "{$this->tempDir}/scaffold.json";
 
         file_put_contents($manifestPath, '{}');
 
+        /**
+         * `default: true` forces the mocker to return `false` for every `file_get_contents` in the Manifest namespace,
+         * independent of how the host platform normalizes the path (Windows backslashes vs. POSIX forward slashes).
+         */
         MockerState::addCondition(
             'yii\\scaffold\\Manifest',
             'file_get_contents',
-            [$manifestPath, false, null, 0, null],
+            [],
             false,
+            default: true,
         );
 
         $package = self::createStub(PackageInterface::class);
@@ -139,15 +143,10 @@ final class ManifestLoaderTest extends TestCase
         $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
         $package->method('getName')->willReturn('yii2-extensions/bad');
 
-        try {
-            $this->expectException(RuntimeException::class);
-            $this->expectExceptionMessage('could not read manifest file');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('could not read manifest file');
 
-            (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
-        } finally {
-            @unlink($manifestPath);
-            @rmdir($providerPath);
-        }
+        (new ManifestLoader(new ManifestSchema()))->load($package, $this->tempDir);
     }
 
     public function testExternalManifestWithBackslashAbsolutePathThrows(): void
@@ -280,14 +279,8 @@ final class ManifestLoaderTest extends TestCase
 
     public function testExternalManifestWithNonObjectJsonThrows(): void
     {
-        $providerPath = sys_get_temp_dir() . '/scaffold-non-object-manifest-' . uniqid();
-
-        if (!mkdir($providerPath, 0777, recursive: true)) {
-            self::fail("Could not create fixture directory '{$providerPath}'.");
-        }
-
         // write a JSON payload that decodes to a scalar, not an object.
-        file_put_contents("{$providerPath}/scaffold.json", '"just a string"');
+        file_put_contents("{$this->tempDir}/scaffold.json", '"just a string"');
 
         $package = self::createStub(PackageInterface::class);
 
@@ -302,15 +295,10 @@ final class ManifestLoaderTest extends TestCase
             ->method('getName')
             ->willReturn('yii2-extensions/bad');
 
-        try {
-            $this->expectException(RuntimeException::class);
-            $this->expectExceptionMessage('must decode to an object');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must decode to an object');
 
-            (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
-        } finally {
-            @unlink("{$providerPath}/scaffold.json");
-            @rmdir($providerPath);
-        }
+        (new ManifestLoader(new ManifestSchema()))->load($package, $this->tempDir);
     }
 
     public function testExternalManifestWithTraversalPathThrows(): void
@@ -505,5 +493,15 @@ final class ManifestLoaderTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpTempDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTempDirectory();
     }
 }

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -26,10 +26,40 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'a.php' => ['source' => 'stubs/a.php', 'mode' => 'replace'],
-                    'b.php' => ['source' => 'stubs/b.php', 'mode' => 'preserve'],
-                    'c.txt' => ['source' => 'stubs/c.txt', 'mode' => 'append'],
-                    'd.txt' => ['source' => 'stubs/d.txt', 'mode' => 'prepend'],
+                    'a.php' => [
+                        'source' => 'stubs/a.php',
+                        'mode' => 'replace',
+                    ],
+                    'b.php' => [
+                        'source' => 'stubs/b.php',
+                        'mode' => 'preserve',
+                    ],
+                    'c.txt' => [
+                        'source' => 'stubs/c.txt',
+                        'mode' => 'append',
+                    ],
+                    'd.txt' => [
+                        'source' => 'stubs/d.txt',
+                        'mode' => 'prepend',
+                    ],
+                ],
+            ],
+        );
+    }
+
+    public function testDestinationKeyWithIntegerThrows(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('file-mapping key must be a non-empty string');
+
+        (new ManifestSchema())->validate(
+            [
+                // an integer key bypasses PHP's string-key conversion and triggers the is_string check.
+                'file-mapping' => [
+                    [
+                        'source' => 'stubs/x.php',
+                        'mode' => 'replace',
+                    ],
                 ],
             ],
         );
@@ -54,7 +84,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'config/params.php' => ['source' => '', 'mode' => 'preserve'],
+                    'config/params.php' => [
+                        'source' => '',
+                        'mode' => 'preserve',
+                    ],
                 ],
             ],
         );
@@ -68,7 +101,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'config/params.php' => ['source' => 'stubs/params.php', 'mode' => 'unknown-mode'],
+                    'config/params.php' => [
+                        'source' => 'stubs/params.php',
+                        'mode' => 'unknown-mode',
+                    ],
                 ],
             ],
         );
@@ -142,7 +178,10 @@ final class ManifestSchemaTest extends TestCase
         $result = (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'nginx.conf' => ['source' => 'stubs/nginx.conf', 'mode' => 'replace'],
+                    'nginx.conf' => [
+                        'source' => 'stubs/nginx.conf',
+                        'mode' => 'replace',
+                    ],
                 ],
             ],
         );
@@ -172,7 +211,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    '.gitignore' => ['source' => 'stubs/.gitignore', 'mode' => 'append'],
+                    '.gitignore' => [
+                        'source' => 'stubs/.gitignore',
+                        'mode' => 'append',
+                    ],
                 ],
             ],
         );
@@ -185,7 +227,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    '.env.dist' => ['source' => 'stubs/.env.dist', 'mode' => 'prepend'],
+                    '.env.dist' => [
+                        'source' => 'stubs/.env.dist',
+                        'mode' => 'prepend',
+                    ],
                 ],
             ],
         );
@@ -198,7 +243,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'config/params.php' => ['source' => 'stubs/params.php', 'mode' => 'preserve'],
+                    'config/params.php' => [
+                        'source' => 'stubs/params.php',
+                        'mode' => 'preserve',
+                    ],
                 ],
             ],
         );
@@ -210,7 +258,10 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(
             [
                 'file-mapping' => [
-                    'config/web.php' => ['source' => 'stubs/web.php', 'mode' => 'replace'],
+                    'config/web.php' => [
+                        'source' => 'stubs/web.php',
+                        'mode' => 'replace',
+                    ],
                 ],
             ],
         );

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\unit;
 
+use Composer\Composer;
+use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\NullIO;
 use Composer\Plugin\{Capable, PluginInterface};
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\{DoesNotPerformAssertions, Group};
 use PHPUnit\Framework\TestCase;
-use yii\scaffold\Plugin;
+use yii\scaffold\{EventSubscriber, Plugin};
 
 /**
  * Unit tests for {@see Plugin} interface implementations and capabilities.
@@ -18,6 +21,71 @@ use yii\scaffold\Plugin;
 #[Group('scaffold')]
 final class PluginTest extends TestCase
 {
+    public function testActivateRegistersSubscriberOnEventDispatcher(): void
+    {
+        $dispatcher = self::createMock(EventDispatcher::class);
+
+        $dispatcher
+            ->expects(self::once())
+            ->method('addSubscriber')
+            ->with(self::isInstanceOf(EventSubscriber::class));
+
+        $composer = self::createStub(Composer::class);
+        $composer->method('getEventDispatcher')->willReturn($dispatcher);
+
+        (new Plugin())->activate($composer, new NullIO());
+    }
+
+    public function testDeactivateIsIdempotentWhenCalledTwice(): void
+    {
+        $dispatcher = self::createMock(EventDispatcher::class);
+
+        $dispatcher->expects(self::once())->method('addSubscriber');
+        $dispatcher->expects(self::once())->method('removeListener');
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getEventDispatcher')->willReturn($dispatcher);
+
+        $plugin = new Plugin();
+        $plugin->activate($composer, new NullIO());
+        $plugin->deactivate($composer, new NullIO());
+        $plugin->deactivate($composer, new NullIO());
+    }
+
+    public function testDeactivateIsNoopWhenNotActivated(): void
+    {
+        $dispatcher = self::createMock(EventDispatcher::class);
+
+        $dispatcher->expects(self::never())->method('removeListener');
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getEventDispatcher')->willReturn($dispatcher);
+
+        (new Plugin())->deactivate($composer, new NullIO());
+    }
+
+    public function testDeactivateRemovesSubscriberAfterActivate(): void
+    {
+        $dispatcher = self::createMock(EventDispatcher::class);
+
+        $dispatcher->expects(self::once())->method('addSubscriber');
+        $dispatcher
+            ->expects(self::once())
+            ->method('removeListener')
+            ->with(self::isInstanceOf(EventSubscriber::class));
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getEventDispatcher')->willReturn($dispatcher);
+
+        $plugin = new Plugin();
+
+        $plugin->activate($composer, new NullIO());
+        $plugin->deactivate($composer, new NullIO());
+    }
+
     public function testGetCapabilitiesReturnsEmptyArray(): void
     {
         self::assertCount(
@@ -43,5 +111,15 @@ final class PluginTest extends TestCase
             new Plugin(),
             'Plugin does not implement the PluginInterface.',
         );
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testUninstallIsNoop(): void
+    {
+        $composer = self::createStub(Composer::class);
+
+        // `uninstall()` is an explicit no-op per PluginInterface; this test guards against accidentally adding behavior
+        // that would throw during `composer remove`.
+        (new Plugin())->uninstall($composer, new NullIO());
     }
 }

--- a/tests/unit/Scaffold/ApplierTest.php
+++ b/tests/unit/Scaffold/ApplierTest.php
@@ -32,7 +32,7 @@ final class ApplierTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('destination');
 
-        // traversal is caught before the realpath check no real project dir needed.
+        // traversal is caught before the realpath check; no real project dir needed.
         $this->makeApplier()->apply(
             $this->makeMapping(destination: '../../../etc/passwd'),
             "{$this->tempDir}/project",

--- a/tests/unit/Scaffold/ApplierTest.php
+++ b/tests/unit/Scaffold/ApplierTest.php
@@ -32,7 +32,7 @@ final class ApplierTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('destination');
 
-        // traversal is caught before the realpath check — no real project dir needed.
+        // traversal is caught before the realpath check no real project dir needed.
         $this->makeApplier()->apply(
             $this->makeMapping(destination: '../../../etc/passwd'),
             "{$this->tempDir}/project",

--- a/tests/unit/Scaffold/Lock/HasherTest.php
+++ b/tests/unit/Scaffold/Lock/HasherTest.php
@@ -131,6 +131,31 @@ final class HasherTest extends TestCase
         (new Hasher())->hash($file);
     }
 
+    public function testHashThrowsWhenHashFileReturnsFalse(): void
+    {
+        $file = "{$this->tempDir}/broken-hash.txt";
+
+        file_put_contents($file, 'content');
+
+        // real file is readable; force `hash_file()` itself to report false to hit the post-read failure branch.
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'hash_file',
+            [
+                'sha256',
+                $file,
+                false,
+                [],
+            ],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('file is unreadable or does not exist');
+
+        (new Hasher())->hash($file);
+    }
+
     protected function setUp(): void
     {
         $this->setUpTempDirectory();

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -203,7 +203,11 @@ final class LockFileTest extends TestCase
 
     public function testReadThrowsWhenFileGetContentsFails(): void
     {
-        $path = "{$this->tempDir}/scaffold-lock.json";
+        $lock = new LockFile($this->tempDir);
+
+        // ask the LockFile for the exact path so the mocker match honors the platform's DIRECTORY_SEPARATOR.
+        $path = $lock->getPath();
+
         file_put_contents($path, '{"providers":{},"files":{}}');
 
         MockerState::addCondition(
@@ -216,7 +220,7 @@ final class LockFileTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not read lock file');
 
-        (new LockFile($this->tempDir))->read();
+        $lock->read();
     }
 
     public function testReadThrowsWhenJsonDecodesToNonObject(): void
@@ -295,7 +299,10 @@ final class LockFileTest extends TestCase
 
     public function testWriteThrowsWhenPersistenceFails(): void
     {
-        $path = "{$this->tempDir}/scaffold-lock.json";
+        $lock = new LockFile($this->tempDir);
+
+        $path = $lock->getPath();
+
         $tmp = "{$path}.tmp";
 
         // simulate `file_put_contents` succeeding but `rename` failing, exercising the cleanup + throw branch.
@@ -313,7 +320,7 @@ final class LockFileTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not write lock file');
 
-        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
+        $lock->write(['providers' => [], 'files' => []]);
     }
 
     public function testWriteUsesUnescapedSlashes(): void

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -139,7 +139,7 @@ final class LockFileTest extends TestCase
 
         $first = $lock->read();
 
-        // remove the file from disk — subsequent reads must still hit the in-memory cache.
+        // remove the file from disk subsequent reads must still hit the in-memory cache.
         unlink($this->tempDir . '/scaffold-lock.json');
 
         self::assertSame(
@@ -225,7 +225,7 @@ final class LockFileTest extends TestCase
 
     public function testReadThrowsWhenJsonDecodesToNonObject(): void
     {
-        // valid JSON, but it decodes to a scalar — `is_array($decoded)` must be `false`, triggering the structural check.
+        // valid JSON, but it decodes to a scalar `is_array($decoded)` must be `false`, triggering the structural check.
         file_put_contents($this->tempDir . '/scaffold-lock.json', '"just a string"');
 
         $this->expectException(RuntimeException::class);

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -7,6 +7,8 @@ namespace yii\scaffold\tests\unit\Scaffold\Lock;
 use JsonException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Scaffold\Lock\LockFile;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
@@ -199,6 +201,35 @@ final class LockFileTest extends TestCase
         (new LockFile($this->tempDir))->read();
     }
 
+    public function testReadThrowsWhenFileGetContentsFails(): void
+    {
+        $path = "{$this->tempDir}/scaffold-lock.json";
+        file_put_contents($path, '{"providers":{},"files":{}}');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'file_get_contents',
+            [$path, false, null, 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read lock file');
+
+        (new LockFile($this->tempDir))->read();
+    }
+
+    public function testReadThrowsWhenJsonDecodesToNonObject(): void
+    {
+        // valid JSON, but it decodes to a scalar — `is_array($decoded)` must be `false`, triggering the structural check.
+        file_put_contents($this->tempDir . '/scaffold-lock.json', '"just a string"');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not contain a valid JSON object');
+
+        (new LockFile($this->tempDir))->read();
+    }
+
     public function testWriteAndReadRoundTrip(): void
     {
         $lock = new LockFile($this->tempDir);
@@ -260,6 +291,29 @@ final class LockFileTest extends TestCase
             $decoded,
             'Decoded JSON should be an array',
         );
+    }
+
+    public function testWriteThrowsWhenPersistenceFails(): void
+    {
+        $path = "{$this->tempDir}/scaffold-lock.json";
+        $tmp = "{$path}.tmp";
+
+        // simulate `file_put_contents` succeeding but `rename` failing, exercising the cleanup + throw branch.
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Lock',
+            'rename',
+            [
+                $tmp,
+                $path,
+                null,
+            ],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write lock file');
+
+        (new LockFile($this->tempDir))->write(['providers' => [], 'files' => []]);
     }
 
     public function testWriteUsesUnescapedSlashes(): void

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -10,6 +10,7 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{AppendMode, ApplyOutcome};
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -112,7 +113,11 @@ final class AppendModeTest extends TestCase
 
     public function testThrowsWhenSourceReadFails(): void
     {
-        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+        /**
+         * Compute the exact source path via `PathResolver::source()` so the mocker match aligns with
+         * `DIRECTORY_SEPARATOR` on every platform (Windows NTFS path normalization differs from POSIX).
+         */
+        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
 
         mkdir(dirname($sourcePath), 0777, recursive: true);
         file_put_contents($sourcePath, 'x');
@@ -138,7 +143,8 @@ final class AppendModeTest extends TestCase
     public function testThrowsWhenWriteFails(): void
     {
         $projectDir = "{$this->tempDir}/project";
-        $destination = "{$projectDir}/output.txt";
+
+        $destination = PathResolver::destination($projectDir, 'output.txt');
 
         $this->makeSourceFile('data');
 

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -10,7 +10,6 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{AppendMode, ApplyOutcome};
-use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -113,20 +112,18 @@ final class AppendModeTest extends TestCase
 
     public function testThrowsWhenSourceReadFails(): void
     {
+        $this->makeSourceFile('x');
+
         /**
-         * Compute the exact source path via `PathResolver::source()` so the mocker match aligns with
-         * `DIRECTORY_SEPARATOR` on every platform (Windows NTFS path normalization differs from POSIX).
+         * `default: true` makes the mocker unconditionally fail every `file_get_contents` in the Modes namespace no
+         * strict argument matching, so the test is immune to future changes in how the mode assembles paths.
          */
-        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
-
-        mkdir(dirname($sourcePath), 0777, recursive: true);
-        file_put_contents($sourcePath, 'x');
-
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',
-            [$sourcePath, false, null, 0, null],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
@@ -142,22 +139,14 @@ final class AppendModeTest extends TestCase
 
     public function testThrowsWhenWriteFails(): void
     {
-        $projectDir = "{$this->tempDir}/project";
-
-        $destination = PathResolver::destination($projectDir, 'output.txt');
-
         $this->makeSourceFile('data');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_put_contents',
-            [
-                $destination,
-                'data',
-                0,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
@@ -165,7 +154,7 @@ final class AppendModeTest extends TestCase
 
         (new AppendMode())->apply(
             $this->makeMapping(),
-            $projectDir,
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\unit\Scaffold\Modes;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
@@ -50,7 +51,7 @@ final class AppendModeTest extends TestCase
 
         $result = (new AppendMode())->apply(
             $this->makeMapping('a/b/c/deep.txt', 'stubs/nested/deep.txt'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
@@ -106,6 +107,61 @@ final class AppendModeTest extends TestCase
             $hasher->hash("{$this->tempDir}/project/output.txt"),
             $result->newHash,
             'AppendMode must return a new hash that matches the actual content of the written file.',
+        );
+    }
+
+    public function testThrowsWhenSourceReadFails(): void
+    {
+        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        mkdir(dirname($sourcePath), 0777, recursive: true);
+        file_put_contents($sourcePath, 'x');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_get_contents',
+            [$sourcePath, false, null, 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read source file');
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            "{$this->tempDir}/project",
+            new Hasher(),
+            null,
+        );
+    }
+
+    public function testThrowsWhenWriteFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+        $destination = "{$projectDir}/output.txt";
+
+        $this->makeSourceFile('data');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_put_contents',
+            [
+                $destination,
+                'data',
+                0,
+                null,
+            ],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to');
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
         );
     }
 
@@ -232,7 +288,7 @@ final class AppendModeTest extends TestCase
             source: $source,
             mode: 'append',
             providerName: 'test/provider',
-            providerPath: $this->tempDir . '/provider',
+            providerPath: "{$this->tempDir}/provider",
         );
     }
 

--- a/tests/unit/Scaffold/Modes/PrependModeTest.php
+++ b/tests/unit/Scaffold/Modes/PrependModeTest.php
@@ -10,6 +10,7 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PrependMode};
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -142,7 +143,8 @@ final class PrependModeTest extends TestCase
     public function testThrowsWhenDestinationReadFails(): void
     {
         $projectDir = "{$this->tempDir}/project";
-        $destination = "{$projectDir}/output.txt";
+
+        $destination = PathResolver::destination($projectDir, 'output.txt');
 
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($destination, 'existing');
@@ -152,7 +154,13 @@ final class PrependModeTest extends TestCase
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',
-            [$destination, false, null, 0, null],
+            [
+                $destination,
+                false,
+                null,
+                0,
+                null,
+            ],
             false,
         );
 
@@ -164,7 +172,7 @@ final class PrependModeTest extends TestCase
 
     public function testThrowsWhenSourceReadFails(): void
     {
-        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
 
         mkdir(dirname($sourcePath), 0777, recursive: true);
         file_put_contents($sourcePath, 'x');
@@ -172,7 +180,13 @@ final class PrependModeTest extends TestCase
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',
-            [$sourcePath, false, null, 0, null],
+            [
+                $sourcePath,
+                false,
+                null,
+                0,
+                null,
+            ],
             false,
         );
 
@@ -190,14 +204,19 @@ final class PrependModeTest extends TestCase
     public function testThrowsWhenWriteFails(): void
     {
         $projectDir = "{$this->tempDir}/project";
-        $destination = "{$projectDir}/output.txt";
+        $destination = PathResolver::destination($projectDir, 'output.txt');
 
         $this->makeSourceFile('source');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_put_contents',
-            [$destination, 'source', 0, null],
+            [
+                $destination,
+                'source',
+                0,
+                null,
+            ],
             false,
         );
 

--- a/tests/unit/Scaffold/Modes/PrependModeTest.php
+++ b/tests/unit/Scaffold/Modes/PrependModeTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\unit\Scaffold\Modes;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
-use yii\scaffold\Scaffold\Modes\ApplyOutcome;
-use yii\scaffold\Scaffold\Modes\PrependMode;
+use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PrependMode};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -27,13 +28,20 @@ final class PrependModeTest extends TestCase
 
         $result = (new PrependMode())->apply(
             $this->makeMapping('a/b/c/deep.txt', 'stubs/nested/deep.txt'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertFileExists($this->tempDir . '/project/a/b/c/deep.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'PrependMode must create intermediate directories when they do not exist.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/a/b/c/deep.txt",
+            'PrependMode must create the file in the expected location.',
+        );
     }
 
     public function testOutcomeIsAlwaysWritten(): void
@@ -42,17 +50,22 @@ final class PrependModeTest extends TestCase
 
         $result = (new PrependMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             'sha256:ignored-hash',
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            "PrependMode must always return 'ApplyOutcome::Written' regardless of the previous file state.",
+        );
     }
 
     public function testPrependContentComesBeforeExistingContent(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'EXISTING');
 
@@ -67,14 +80,26 @@ final class PrependModeTest extends TestCase
 
         $content = file_get_contents($projectDir . '/output.txt');
 
-        self::assertNotFalse($content);
-        self::assertStringStartsWith('PREPENDED', $content);
-        self::assertStringEndsWith('EXISTING', $content);
+        self::assertNotFalse(
+            $content,
+            'Failed to read the content of the destination file after applying PrependMode.',
+        );
+        self::assertStringStartsWith(
+            'PREPENDED',
+            $content,
+            'PrependMode must prepend the content correctly.',
+        );
+        self::assertStringEndsWith(
+            'EXISTING',
+            $content,
+            'PrependMode must preserve the existing content.',
+        );
     }
 
     public function testPrependsToExistingFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
@@ -87,7 +112,11 @@ final class PrependModeTest extends TestCase
             null,
         );
 
-        self::assertSame('prepended existing', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            'prepended existing',
+            file_get_contents($projectDir . '/output.txt'),
+            'PrependMode must prepend the content correctly.',
+        );
     }
 
     public function testResultHashMatchesActualFileHash(): void
@@ -98,12 +127,84 @@ final class PrependModeTest extends TestCase
 
         $result = (new PrependMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             $hasher,
             null,
         );
 
-        self::assertSame($hasher->hash($this->tempDir . '/project/output.txt'), $result->newHash);
+        self::assertSame(
+            $hasher->hash("{$this->tempDir}/project/output.txt"),
+            $result->newHash,
+            'PrependMode must return the correct hash for the new file content.',
+        );
+    }
+
+    public function testThrowsWhenDestinationReadFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+        $destination = "{$projectDir}/output.txt";
+
+        mkdir($projectDir, 0777, recursive: true);
+        file_put_contents($destination, 'existing');
+
+        $this->makeSourceFile('source');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_get_contents',
+            [$destination, false, null, 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read destination file');
+
+        (new PrependMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
+    }
+
+    public function testThrowsWhenSourceReadFails(): void
+    {
+        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        mkdir(dirname($sourcePath), 0777, recursive: true);
+        file_put_contents($sourcePath, 'x');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_get_contents',
+            [$sourcePath, false, null, 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read source file');
+
+        (new PrependMode())->apply(
+            $this->makeMapping(),
+            "{$this->tempDir}/project",
+            new Hasher(),
+            null,
+        );
+    }
+
+    public function testThrowsWhenWriteFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+        $destination = "{$projectDir}/output.txt";
+
+        $this->makeSourceFile('source');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_put_contents',
+            [$destination, 'source', 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to');
+
+        (new PrependMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void
@@ -112,14 +213,25 @@ final class PrependModeTest extends TestCase
 
         $result = (new PrependMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertSame('hello', file_get_contents($this->tempDir . '/project/output.txt'));
-        self::assertNull($result->warning);
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'PrependMode must return the correct outcome when writing a new file.',
+        );
+        self::assertSame(
+            'hello',
+            file_get_contents("{$this->tempDir}/project/output.txt"),
+            'PrependMode must write the correct content when the destination file does not exist.',
+        );
+        self::assertNull(
+            $result->warning,
+            'PrependMode must not return a warning when writing a new file.',
+        );
     }
 
     protected function setUp(): void
@@ -139,13 +251,14 @@ final class PrependModeTest extends TestCase
             source: $source,
             mode: 'prepend',
             providerName: 'test/provider',
-            providerPath: $this->tempDir . '/provider',
+            providerPath: "{$this->tempDir}/provider",
         );
     }
 
     private function makeSourceFile(string $content = 'prepended content', string $relative = 'stubs/source.txt'): void
     {
-        $path = $this->tempDir . '/provider/' . $relative;
+        $path = "{$this->tempDir}/provider/{$relative}";
+
         mkdir(dirname($path), 0777, recursive: true);
         file_put_contents($path, $content);
     }

--- a/tests/unit/Scaffold/Modes/PrependModeTest.php
+++ b/tests/unit/Scaffold/Modes/PrependModeTest.php
@@ -10,7 +10,6 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PrependMode};
-use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -144,18 +143,32 @@ final class PrependModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        $destination = PathResolver::destination($projectDir, 'output.txt');
-
         mkdir($projectDir, 0777, recursive: true);
-        file_put_contents($destination, 'existing');
+        file_put_contents("{$projectDir}/output.txt", 'existing');
 
-        $this->makeSourceFile('source');
+        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+        mkdir(dirname($sourcePath), 0777, recursive: true);
+        file_put_contents($sourcePath, 'source');
+
+        /**
+         * `PrependMode::apply()` calls `file_get_contents` twice — once for the source, once for the destination. This
+         * test must exercise ONLY the destination branch, so we cannot use `default: true` here (it would trip the
+         * source branch first). A callable-as-result with `default: true` also does not work because the mocker stores
+         * defaults verbatim and returns them without invocation. Strict argument matching on the destination path is
+         * the only mechanism left for this narrow case.
+         */
+        $destBasename = 'output.txt';
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',
             [
-                $destination,
+                /**
+                 * match the destination argument by absolute path. `PrependMode` uses `PathResolver::destination`,
+                 * which concatenates `rtrim($projectRoot, '/\\') . DIRECTORY_SEPARATOR . $mapping->destination` we
+                 * reproduce that exactly here.
+                 */
+                rtrim($projectDir, '/\\') . DIRECTORY_SEPARATOR . $destBasename,
                 false,
                 null,
                 0,
@@ -172,22 +185,14 @@ final class PrependModeTest extends TestCase
 
     public function testThrowsWhenSourceReadFails(): void
     {
-        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
-
-        mkdir(dirname($sourcePath), 0777, recursive: true);
-        file_put_contents($sourcePath, 'x');
+        $this->makeSourceFile('x');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',
-            [
-                $sourcePath,
-                false,
-                null,
-                0,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
@@ -203,27 +208,20 @@ final class PrependModeTest extends TestCase
 
     public function testThrowsWhenWriteFails(): void
     {
-        $projectDir = "{$this->tempDir}/project";
-        $destination = PathResolver::destination($projectDir, 'output.txt');
-
         $this->makeSourceFile('source');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_put_contents',
-            [
-                $destination,
-                'source',
-                0,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not write to');
 
-        (new PrependMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
+        (new PrependMode())->apply($this->makeMapping(), "{$this->tempDir}/project", new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -10,7 +10,6 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PreserveMode};
-use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -135,28 +134,20 @@ final class PreserveModeTest extends TestCase
 
     public function testThrowsWhenCopyFails(): void
     {
-        $projectDir = "{$this->tempDir}/project";
-
-        $destination = PathResolver::destination($projectDir, 'output.txt');
-        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
-
         $this->makeSourceFile('content');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'copy',
-            [
-                $sourcePath,
-                $destination,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not copy');
 
-        (new PreserveMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
+        (new PreserveMode())->apply($this->makeMapping(), "{$this->tempDir}/project", new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -9,8 +9,8 @@ use RuntimeException;
 use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
-use yii\scaffold\Scaffold\Modes\ApplyOutcome;
-use yii\scaffold\Scaffold\Modes\PreserveMode;
+use yii\scaffold\Scaffold\Modes\{ApplyOutcome, PreserveMode};
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -136,8 +136,9 @@ final class PreserveModeTest extends TestCase
     public function testThrowsWhenCopyFails(): void
     {
         $projectDir = "{$this->tempDir}/project";
-        $destination = "{$projectDir}/output.txt";
-        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        $destination = PathResolver::destination($projectDir, 'output.txt');
+        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
 
         $this->makeSourceFile('content');
 

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -47,7 +47,7 @@ final class PreserveModeTest extends TestCase
 
     public function testLockHashIsIgnored(): void
     {
-        // preserveMode never overwrites — the lock hash is irrelevant.
+        // preserveMode never overwrites the lock hash is irrelevant.
         $projectDir = "{$this->tempDir}/project";
 
         mkdir($projectDir, 0777, recursive: true);

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\unit\Scaffold\Modes;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\ApplyOutcome;
@@ -27,19 +29,27 @@ final class PreserveModeTest extends TestCase
 
         $result = (new PreserveMode())->apply(
             $this->makeMapping('a/b/c/deep.txt', 'stubs/nested/deep.txt'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertFileExists($this->tempDir . '/project/a/b/c/deep.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'Expected file to be written when intermediate directories are created.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/a/b/c/deep.txt",
+            'Expected file to exist after creating intermediate directories.',
+        );
     }
 
     public function testLockHashIsIgnored(): void
     {
-        // PreserveMode never overwrites — the lock hash is irrelevant.
-        $projectDir = $this->tempDir . '/project';
+        // preserveMode never overwrites — the lock hash is irrelevant.
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
@@ -52,13 +62,22 @@ final class PreserveModeTest extends TestCase
             'sha256:some-recorded-hash',
         );
 
-        self::assertSame(ApplyOutcome::Skipped, $result->outcome);
-        self::assertSame('user content', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'PreserveMode must skip the file when it already exists.',
+        );
+        self::assertSame(
+            'user content',
+            file_get_contents($projectDir . '/output.txt'),
+            'Existing file content must not be modified.',
+        );
     }
 
     public function testSkippedResultHashIsHashOfExistingFile(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
@@ -74,12 +93,17 @@ final class PreserveModeTest extends TestCase
             null,
         );
 
-        self::assertSame($expected, $result->newHash);
+        self::assertSame(
+            $expected,
+            $result->newHash,
+            'PreserveMode must return the correct hash for the existing file.',
+        );
     }
 
     public function testSkipsFileWhenDestinationAlreadyExists(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
@@ -92,10 +116,46 @@ final class PreserveModeTest extends TestCase
             null,
         );
 
-        self::assertSame(ApplyOutcome::Skipped, $result->outcome);
-        // Existing file must not be modified.
-        self::assertSame('user content', file_get_contents($projectDir . '/output.txt'));
-        self::assertNull($result->warning);
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'PreserveMode must skip the file when it already exists.',
+        );
+        // existing file must not be modified.
+        self::assertSame(
+            'user content',
+            file_get_contents($projectDir . '/output.txt'),
+            'Existing file content must not be modified.',
+        );
+        self::assertNull(
+            $result->warning,
+            'PreserveMode must not produce a warning when skipping a file.',
+        );
+    }
+
+    public function testThrowsWhenCopyFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+        $destination = "{$projectDir}/output.txt";
+        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        $this->makeSourceFile('content');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'copy',
+            [
+                $sourcePath,
+                $destination,
+                null,
+            ],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not copy');
+
+        (new PreserveMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void
@@ -104,15 +164,29 @@ final class PreserveModeTest extends TestCase
 
         $result = (new PreserveMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertStringStartsWith('sha256:', $result->newHash);
-        self::assertNull($result->warning);
-        self::assertFileExists($this->tempDir . '/project/output.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'PreserveMode must write the file when it does not already exist.',
+        );
+        self::assertStringStartsWith(
+            'sha256:',
+            $result->newHash,
+            "PreserveMode must return a hash starting with 'sha256'.",
+        );
+        self::assertNull(
+            $result->warning,
+            'PreserveMode must not produce a warning when writing a file.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/output.txt",
+            'PreserveMode must create the output file.',
+        );
     }
 
     protected function setUp(): void
@@ -132,13 +206,14 @@ final class PreserveModeTest extends TestCase
             source: $source,
             mode: 'preserve',
             providerName: 'test/provider',
-            providerPath: $this->tempDir . '/provider',
+            providerPath: "{$this->tempDir}/provider",
         );
     }
 
     private function makeSourceFile(string $content = 'stub content', string $relative = 'stubs/source.txt'): void
     {
-        $path = $this->tempDir . '/provider/' . $relative;
+        $path = "{$this->tempDir}/provider/{$relative}";
+
         mkdir(dirname($path), 0777, recursive: true);
         file_put_contents($path, $content);
     }

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -10,7 +10,6 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{ApplyOutcome, ReplaceMode};
-use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -148,28 +147,20 @@ final class ReplaceModeTest extends TestCase
 
     public function testThrowsWhenCopyFails(): void
     {
-        $projectDir = "{$this->tempDir}/project";
-
-        $destination = PathResolver::destination($projectDir, 'output.txt');
-        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
-
         $this->makeSourceFile('content');
 
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'copy',
-            [
-                $sourcePath,
-                $destination,
-                null,
-            ],
+            [],
             false,
+            default: true,
         );
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not copy');
 
-        (new ReplaceMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
+        (new ReplaceMode())->apply($this->makeMapping(), "{$this->tempDir}/project", new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace yii\scaffold\tests\unit\Scaffold\Modes;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
-use yii\scaffold\Scaffold\Modes\ApplyOutcome;
-use yii\scaffold\Scaffold\Modes\ReplaceMode;
+use yii\scaffold\Scaffold\Modes\{ApplyOutcome, ReplaceMode};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -27,18 +28,26 @@ final class ReplaceModeTest extends TestCase
 
         $result = (new ReplaceMode())->apply(
             $this->makeMapping('a/b/c/deep.txt', 'stubs/nested/deep.txt'),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             new Hasher(),
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertFileExists($this->tempDir . '/project/a/b/c/deep.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'Expected file to be written successfully, even if intermediate directories do not exist.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/a/b/c/deep.txt",
+            'Expected file to exist after creating intermediate directories.',
+        );
     }
 
     public function testOverwritesFileWhenHashMatchesLockHash(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'original scaffold content');
 
@@ -54,8 +63,16 @@ final class ReplaceModeTest extends TestCase
             $lockHash,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertSame('updated stub content', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'Expected file to be overwritten when hash matches lock hash.',
+        );
+        self::assertSame(
+            'updated stub content',
+            file_get_contents($projectDir . '/output.txt'),
+            'Expected file content to be updated when hash matches lock hash.',
+        );
     }
 
     public function testResultHashMatchesActualFileHash(): void
@@ -66,26 +83,32 @@ final class ReplaceModeTest extends TestCase
 
         $result = (new ReplaceMode())->apply(
             $this->makeMapping(),
-            $this->tempDir . '/project',
+            "{$this->tempDir}/project",
             $hasher,
             null,
         );
 
-        $actualHash = $hasher->hash($this->tempDir . '/project/output.txt');
+        $actualHash = $hasher->hash("{$this->tempDir}/project/output.txt");
 
-        self::assertSame($actualHash, $result->newHash);
+        self::assertSame(
+            $actualHash,
+            $result->newHash,
+            'Expected result hash to match the actual file hash.',
+        );
     }
 
     public function testSkipsFileWhenUserHasModifiedIt(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'original scaffold content');
 
         $this->makeSourceFile('updated stub content');
 
         $hasher = new Hasher();
-        // Lock hash recorded for original; user then modified the file to different content.
+
+        // lock hash recorded for original; user then modified the file to different content.
         $lockHash = 'sha256:' . hash('sha256', 'the-original-hash-that-no-longer-matches');
 
         $result = (new ReplaceMode())->apply(
@@ -95,12 +118,56 @@ final class ReplaceModeTest extends TestCase
             $lockHash,
         );
 
-        self::assertSame(ApplyOutcome::Skipped, $result->outcome);
-        self::assertSame('', $result->newHash);
-        self::assertNotNull($result->warning);
-        self::assertStringContainsString('output.txt', $result->warning);
-        // File must NOT be overwritten.
-        self::assertSame('original scaffold content', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'Expected file to be skipped when user has modified it.',
+        );
+        self::assertSame(
+            '',
+            $result->newHash,
+            'Expected new hash to be empty when file is skipped.',
+        );
+        self::assertNotNull(
+            $result->warning,
+            'Expected warning to be set when file is skipped.',
+        );
+        self::assertStringContainsString(
+            'output.txt',
+            $result->warning,
+            'Expected warning to mention the file name when file is skipped.',
+        );
+        // file must NOT be overwritten.
+        self::assertSame(
+            'original scaffold content',
+            file_get_contents($projectDir . '/output.txt'),
+            'Expected file content to remain unchanged when file is skipped.',
+        );
+    }
+
+    public function testThrowsWhenCopyFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+        $destination = "{$projectDir}/output.txt";
+        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        $this->makeSourceFile('content');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'copy',
+            [
+                $sourcePath,
+                $destination,
+                null,
+            ],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not copy');
+
+        (new ReplaceMode())->apply($this->makeMapping(), $projectDir, new Hasher(), null);
     }
 
     public function testWritesFileWhenDestinationDoesNotExist(): void
@@ -114,15 +181,30 @@ final class ReplaceModeTest extends TestCase
             null,
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertStringStartsWith('sha256:', $result->newHash);
-        self::assertNull($result->warning);
-        self::assertFileExists($this->tempDir . '/project/output.txt');
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'Expected file to be written when destination does not exist.',
+        );
+        self::assertStringStartsWith(
+            'sha256:',
+            $result->newHash,
+            "Expected new hash to start with 'sha256:'",
+        );
+        self::assertNull(
+            $result->warning,
+            'Expected no warning when file is written.',
+        );
+        self::assertFileExists(
+            "{$this->tempDir}/project/output.txt",
+            'Expected file to exist after being written.',
+        );
     }
 
     public function testWritesFileWhenNoLockHashExists(): void
     {
-        $projectDir = $this->tempDir . '/project';
+        $projectDir = "{$this->tempDir}/project";
+
         mkdir($projectDir, 0777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'any existing content');
 
@@ -135,8 +217,16 @@ final class ReplaceModeTest extends TestCase
             null, // no lock hash — treat as untracked, overwrite unconditionally
         );
 
-        self::assertSame(ApplyOutcome::Written, $result->outcome);
-        self::assertSame('fresh stub', file_get_contents($projectDir . '/output.txt'));
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            'Expected file to be written when no lock hash exists.',
+        );
+        self::assertSame(
+            'fresh stub',
+            file_get_contents($projectDir . '/output.txt'),
+            'Expected file content to match the source when no lock hash exists.',
+        );
     }
 
     protected function setUp(): void
@@ -156,13 +246,14 @@ final class ReplaceModeTest extends TestCase
             source: $source,
             mode: 'replace',
             providerName: 'test/provider',
-            providerPath: $this->tempDir . '/provider',
+            providerPath: "{$this->tempDir}/provider",
         );
     }
 
     private function makeSourceFile(string $content = 'stub content', string $relative = 'stubs/source.txt'): void
     {
-        $path = $this->tempDir . '/provider/' . $relative;
+        $path = "{$this->tempDir}/provider/{$relative}";
+
         mkdir(dirname($path), 0777, recursive: true);
         file_put_contents($path, $content);
     }

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -10,6 +10,7 @@ use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\Modes\{ApplyOutcome, ReplaceMode};
+use yii\scaffold\Scaffold\PathResolver;
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
 /**
@@ -148,8 +149,9 @@ final class ReplaceModeTest extends TestCase
     public function testThrowsWhenCopyFails(): void
     {
         $projectDir = "{$this->tempDir}/project";
-        $destination = "{$projectDir}/output.txt";
-        $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";
+
+        $destination = PathResolver::destination($projectDir, 'output.txt');
+        $sourcePath = PathResolver::source("{$this->tempDir}/provider", 'stubs/source.txt');
 
         $this->makeSourceFile('content');
 

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -216,7 +216,7 @@ final class ReplaceModeTest extends TestCase
             $this->makeMapping(),
             $projectDir,
             new Hasher(),
-            null, // no lock hash — treat as untracked, overwrite unconditionally
+            null, // no lock hash treat as untracked, overwrite unconditionally
         );
 
         self::assertSame(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
