### PR TITLE
feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - feat: add `scaffold/help` console command listing module subcommands with descriptions.
 - feat: port console commands to Symfony Console and ship `vendor/bin/scaffold` as a standalone CLI usable from Yii2, Yii3, Laravel, Symfony, or plain PHP projects.
 - test: kill remaining path-normalization mutants and keep Infection MSI at `100%`.
+- feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,48 +1,52 @@
 # Creating providers
 
-A scaffold provider is any Composer package that declares file mappings under `extra.scaffold` in its `composer.json`.
+A scaffold provider is a Composer package that declares which of its files scaffold should copy into consumer projects
+on `composer install`.
 
-Providers do not need a special package type; any installed package can contribute scaffold files once it appears in
-the root project's `allowed-packages` list.
+Providers do not need a special package type; any installed package can contribute scaffold files once it appears in the
+root project's `allowed-packages` list.
+
+## Manifest shape
+
+Every provider declares a `scaffold` manifest with three keys:
+
+- `copy` (required, array of paths) — directories or files relative to the provider root. Directories are walked
+  recursively.
+- `exclude` (optional, array of glob patterns) — patterns omitted from the walk. Only applies to directory entries in
+  `copy`; explicit file entries bypass this filter.
+- `modes` (optional, map of glob pattern → [file mode](modes.md)) — overrides the default write mode per destination.
+  Exact path matches win over glob matches; the default when no pattern matches is `replace`.
 
 ## Inline manifest
 
-Declare mappings directly in `composer.json` under `extra.scaffold.file-mapping`:
+Declare under `extra.scaffold` in the provider's `composer.json`:
 
 ```json
 {
-    "name": "yii2-extensions/app-base",
+    "name": "yii2-extensions/app-backend",
+    "type": "yii2-scaffold",
     "extra": {
         "scaffold": {
-            "file-mapping": {
-                "config/params.php": {
-                    "source": "stubs/config/params.php",
-                    "mode": "replace"
-                },
-                "config/web.php": {
-                    "source": "stubs/config/web.php",
-                    "mode": "preserve"
-                },
-                ".env.example": {
-                    "source": "stubs/.env.example",
-                    "mode": "append"
-                }
+            "copy": ["src", "config", "migrations", "public", "resources", "yii"],
+            "modes": {
+                "config/*.php":           "preserve",
+                "public/assets/.gitkeep": "preserve",
+                ".env.dist":              "preserve",
+                ".gitignore":             "append"
             }
         }
     }
 }
 ```
 
-Each key is the **destination path** relative to the project root.
-Each value must include `source` (path relative to the provider package root) and `mode`.
-
 ## External manifest
 
-For larger providers, point to a `scaffold.json` file instead of embedding mappings inline:
+For larger providers, point to a `scaffold.json` file next to `composer.json`:
 
 ```json
 {
-    "name": "yii2-extensions/app-nginx",
+    "name": "yii2-extensions/app-backend",
+    "type": "yii2-scaffold",
     "extra": {
         "scaffold": {
             "manifest": "scaffold.json"
@@ -51,24 +55,33 @@ For larger providers, point to a `scaffold.json` file instead of embedding mappi
 }
 ```
 
-`scaffold.json` at the provider root:
+`scaffold.json` at the provider root uses the same `copy` / `exclude` / `modes` shape:
 
 ```json
 {
-    "file-mapping": {
-        "docker/nginx/nginx.conf": {
-            "source": "stubs/nginx/nginx.conf",
-            "mode": "replace"
-        },
-        "docker/nginx/default.conf": {
-            "source": "stubs/nginx/default.conf",
-            "mode": "preserve"
-        }
+    "copy":    ["src", "config", "migrations", "public", "resources", "yii"],
+    "exclude": ["config/test-local.php"],
+    "modes":   {
+        "config/*.php":           "preserve",
+        "public/assets/.gitkeep": "preserve",
+        ".env.dist":              "preserve"
     }
 }
 ```
 
-The plugin resolves `scaffold.json` relative to the provider's installation path inside `vendor/`.
+The plugin resolves the path relative to the provider's installation directory inside `vendor/`.
+
+## Glob syntax
+
+Patterns in `exclude` and the keys of `modes` support:
+
+| Token   | Matches                                                                            |
+| ------- | ---------------------------------------------------------------------------------- |
+| `*`     | Any sequence of characters that does NOT include `/`.                              |
+| `**`    | Any sequence of characters including `/` (crosses directories).                    |
+| `**/`   | Zero or more directory levels (so `**/.gitignore` also matches root `.gitignore`). |
+| `?`     | A single character that is not `/`.                                                |
+| literal | Any other character matches byte-exact.                                            |
 
 ## File modes
 
@@ -81,25 +94,63 @@ The plugin resolves `scaffold.json` relative to the provider's installation path
 
 See [File Modes](modes.md) for a detailed description of each mode and the hash-tracking mechanism.
 
-## Provider layout example
+## Default excludes
+
+The following patterns are hardcoded and always skipped when walking a directory listed in `copy`, so providers never
+accidentally ship their own development metadata:
+
+```
+composer.json, composer.lock, vendor/**
+.git/**, .github/**, .gitattributes, .gitignore
+tests/**, phpunit.xml, phpunit.xml.dist, .phpunit.cache/**, phpunit.cache/**
+phpstan.neon, phpstan.neon.dist, phpstan.cache/**
+infection.json5, infection.json, infection.log, .infection/**
+.editorconfig, .php-cs-fixer.php, .php-cs-fixer.dist.php, ecs.php
+psalm.xml, psalm.xml.dist
+README.md, CHANGELOG.md, LICENSE, docs/**
+scaffold.json, scaffold-lock.json
+runtime/**
+```
+
+A provider that needs to distribute a file matching one of these patterns (for example, a `runtime/.gitignore` template)
+can list the exact path as an explicit file entry in `copy`; explicit file entries bypass the default excludes.
+
+## Provider layout
+
+Because `copy` walks the provider tree directly, providers look like real Yii2 apps — there is no `stubs/` wrapper and
+no per-file declaration:
 
 ```text
-yii2-extensions/app-base/
-├── composer.json          # declares extra.scaffold.file-mapping or extra.scaffold.manifest
+yii2-extensions/app-backend/
+├── composer.json          # declares extra.scaffold or extra.scaffold.manifest
 ├── scaffold.json          # optional external manifest
-└── stubs/
-    ├── config/
-    │   ├── params.php
-    │   └── web.php
-    └── .env.example
+├── src/                   # copied verbatim into the consumer's src/
+├── config/
+├── migrations/
+├── public/
+├── resources/
+├── yii
+├── tests/                 # default-excluded, lives in the provider for its own CI
+├── phpunit.xml            # default-excluded
+├── phpstan.neon           # default-excluded
+└── infection.json5        # default-excluded
 ```
+
+This layout lets the provider be a standalone Yii2 application: you can run `composer install` inside it, then
+`./vendor/bin/phpunit`, `./vendor/bin/phpstan`, and `composer mutation-static` to prove the distributed code works
+before any consumer depends on it.
 
 ## Security model
 
-The plugin validates every mapping before writing:
+The plugin validates every entry before writing:
 
-- **Package allowlist**: the provider must appear in `allowed-packages`. Unknown providers cause an error and no file is written.
-- **Path traversal rejection**: both `source` and `destination` are validated with `realpath()`. Any path that escapes the provider root or the project root is rejected.
+- **Package allowlist**: the provider must appear in `allowed-packages`. Unknown providers cause an error and no file
+  is written.
+- **Path traversal rejection**: entries in `copy` and `exclude` must be relative and must not contain `..` segments.
+  Absolute paths and Windows drive letters are rejected.
+- **File existence**: every path listed in `copy` must exist on disk at expansion time; missing entries fail the run
+  loudly instead of silently skipping.
+- **Walk boundary**: the filesystem walk is constrained to the provider's installation directory inside `vendor/`.
 
 ## Next steps
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -27,12 +27,21 @@ Declare under `extra.scaffold` in the provider's `composer.json`:
     "type": "yii2-scaffold",
     "extra": {
         "scaffold": {
-            "copy": ["src", "config", "migrations", "public", "resources", "yii"],
+            "copy": [
+                "src",
+                "config",
+                "migrations",
+                "public",
+                "resources",
+                "yii",
+                ".env.dist",
+                ".gitignore"
+            ],
             "modes": {
-                "config/*.php":           "preserve",
+                "config/*.php": "preserve",
                 "public/assets/.gitkeep": "preserve",
-                ".env.dist":              "preserve",
-                ".gitignore":             "append"
+                ".env.dist": "preserve",
+                ".gitignore": "append"
             }
         }
     }
@@ -59,12 +68,20 @@ For larger providers, point to a `scaffold.json` file next to `composer.json`:
 
 ```json
 {
-    "copy":    ["src", "config", "migrations", "public", "resources", "yii"],
+    "copy": [
+        "src",
+        "config",
+        "migrations",
+        "public",
+        "resources",
+        "yii",
+        ".env.dist"
+    ],
     "exclude": ["config/test-local.php"],
-    "modes":   {
-        "config/*.php":           "preserve",
+    "modes": {
+        "config/*.php": "preserve",
         "public/assets/.gitkeep": "preserve",
-        ".env.dist":              "preserve"
+        ".env.dist": "preserve"
     }
 }
 ```
@@ -99,7 +116,7 @@ See [File Modes](modes.md) for a detailed description of each mode and the hash-
 The following patterns are hardcoded and always skipped when walking a directory listed in `copy`, so providers never
 accidentally ship their own development metadata:
 
-```
+```text
 composer.json, composer.lock, vendor/**
 .git/**, .github/**, .gitattributes, .gitignore
 tests/**, phpunit.xml, phpunit.xml.dist, .phpunit.cache/**, phpunit.cache/**

--- a/src/EventSubscriber.php
+++ b/src/EventSubscriber.php
@@ -8,7 +8,7 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Script\{Event, ScriptEvents};
 use Throwable;
-use yii\scaffold\Manifest\{ManifestLoader, ManifestSchema};
+use yii\scaffold\Manifest\{ManifestExpander, ManifestLoader, ManifestSchema};
 use yii\scaffold\Scaffold\{Applier, Scaffolder};
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
 use yii\scaffold\Security\{PackageAllowlist, PathValidator};
@@ -99,7 +99,7 @@ final class EventSubscriber implements EventSubscriberInterface
     private function buildScaffolder(array $allowedPackages, string $projectRoot, IOInterface $io): Scaffolder
     {
         return new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist($allowedPackages), new PathValidator(), new Hasher(), $io),
             new LockFile($projectRoot),
             $io,

--- a/src/Manifest/DefaultExcludes.php
+++ b/src/Manifest/DefaultExcludes.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\Manifest;
+
+/**
+ * Built-in exclusion patterns applied when {@see ManifestExpander} walks a directory listed in `scaffold.copy`.
+ *
+ * These patterns guarantee that provider meta-files (composer metadata, CI configuration, docs, etc.) never leak into
+ * the consumer project just because the provider's tree is copied wholesale. Providers that need to distribute a file
+ * that matches a default exclude may list it as an explicit file entry in `copy[]`; explicit file entries bypass the
+ * default excludes by design.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class DefaultExcludes
+{
+    /**
+     * @var list<string> Glob patterns excluded by default from directory walks.
+     */
+    public const PATTERNS = [
+        // Composer metadata.
+        'composer.json',
+        'composer.lock',
+        'vendor/**',
+        // Version control.
+        '.git/**',
+        '.github/**',
+        '.gitattributes',
+        '.gitignore',
+        // Test framework.
+        'tests/**',
+        'phpunit.xml',
+        'phpunit.xml.dist',
+        '.phpunit.cache/**',
+        'phpunit.cache/**',
+        // Static analysis and style.
+        'phpstan.neon',
+        'phpstan.neon.dist',
+        'phpstan.cache/**',
+        '.editorconfig',
+        '.php-cs-fixer.php',
+        '.php-cs-fixer.dist.php',
+        'ecs.php',
+        'psalm.xml',
+        'psalm.xml.dist',
+        // Mutation testing.
+        'infection.json5',
+        'infection.json',
+        'infection.log',
+        '.infection/**',
+        // Documentation and meta.
+        'README.md',
+        'CHANGELOG.md',
+        'LICENSE',
+        'docs/**',
+        // Scaffold metadata itself.
+        'scaffold.json',
+        'scaffold-lock.json',
+        // Runtime bucket (providers ship explicit '.gitignore' if they want).
+        'runtime/**',
+    ];
+
+    /**
+     * Returns `true` when `$relativePath` matches any built-in exclusion pattern.
+     *
+     * @param string $relativePath Path relative to the provider root, normalised to forward slashes.
+     *
+     * @return bool `true` when the path is default-excluded, `false` otherwise.
+     */
+    public static function matches(string $relativePath): bool
+    {
+        foreach (self::PATTERNS as $pattern) {
+            if (Glob::matches($pattern, $relativePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Manifest/DefaultExcludes.php
+++ b/src/Manifest/DefaultExcludes.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace yii\scaffold\Manifest;
 
+use function str_ends_with;
+use function substr;
+
 /**
  * Built-in exclusion patterns applied when {@see ManifestExpander} walks a directory listed in `scaffold.copy`.
  *
@@ -20,7 +23,7 @@ final class DefaultExcludes
     /**
      * @var list<string> Glob patterns excluded by default from directory walks.
      */
-    public const PATTERNS = [
+    public const array PATTERNS = [
         // Composer metadata.
         'composer.json',
         'composer.lock',
@@ -74,6 +77,25 @@ final class DefaultExcludes
     {
         foreach (self::PATTERNS as $pattern) {
             if (Glob::matches($pattern, $relativePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns `true` when `$relativeDir` can be pruned from the walk because a pattern of the form `$relativeDir/**`
+     * would exclude every possible descendant.
+     *
+     * @param string $relativeDir Directory path relative to the walk root, normalised to forward slashes.
+     *
+     * @return bool `true` when descent into the directory is safe to skip entirely, `false` otherwise.
+     */
+    public static function matchesDirectory(string $relativeDir): bool
+    {
+        foreach (self::PATTERNS as $pattern) {
+            if (str_ends_with($pattern, '/**') && substr($pattern, 0, -3) === $relativeDir) {
                 return true;
             }
         }

--- a/src/Manifest/Glob.php
+++ b/src/Manifest/Glob.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\Manifest;
+
+use function preg_match;
+use function preg_quote;
+use function preg_replace_callback;
+
+/**
+ * Glob-to-regex converter and matcher for scaffold manifest patterns.
+ *
+ * Supports the subset used by `scaffold.json`:
+ *
+ * - `*` — any sequence of characters that does NOT include a path separator.
+ * - `**` — any sequence, including path separators (matches across directories).
+ * - `?` — a single character that is not a path separator.
+ * - literals — everything else matches byte-exact.
+ *
+ * Paths are normalised to forward slashes before matching so providers can share patterns across POSIX and Windows.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class Glob
+{
+    /**
+     * Returns `true` when `$path` matches `$pattern` under scaffold's glob semantics.
+     *
+     * @param string $pattern Glob pattern.
+     * @param string $path Relative path to test (normalised to forward slashes).
+     *
+     * @return bool `true` when the pattern matches the full path, `false` otherwise.
+     */
+    public static function matches(string $pattern, string $path): bool
+    {
+        return preg_match(self::toRegex($pattern), $path) === 1;
+    }
+
+    /**
+     * Converts a scaffold glob pattern into an anchored PCRE regex.
+     *
+     * @param string $pattern Glob pattern.
+     *
+     * @return string Anchored PCRE regex matching the full string (e.g. `'#^config/[^/]+\.php$#'`).
+     */
+    public static function toRegex(string $pattern): string
+    {
+        // '**/' expands to "any number of directories including zero" so '**/foo' matches both 'foo' and 'a/b/foo'.
+        // '(string)' cast is defensive; preg_replace_callback only returns null on invalid regex.
+        // @codeCoverageIgnoreStart
+        $regex = (string) preg_replace_callback(
+            '#\*\*/|\*\*|\*|\?|[^*?]+#',
+            static fn(array $match) => match ($match[0]) {
+                '**/' => '(?:.*/)?',
+                '**' => '.*',
+                '*' => '[^/]*',
+                '?' => '[^/]',
+                default => preg_quote($match[0], '#'),
+            },
+            $pattern,
+        );
+        // @codeCoverageIgnoreEnd
+
+        return "#^{$regex}$#";
+    }
+}

--- a/src/Manifest/ManifestExpander.php
+++ b/src/Manifest/ManifestExpander.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\Manifest;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+
+use function is_dir;
+use function is_file;
+use function sort;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function substr;
+
+/**
+ * Expands a validated `scaffold.json` manifest into a flat list of {@see FileMapping} entries.
+ *
+ * Walks each path listed in `copy`:
+ *
+ * - Explicit file entries pass through unconditionally (bypass default excludes).
+ * - Directory entries are walked recursively; the built-in {@see DefaultExcludes} patterns plus the manifest's own
+ *   `exclude[]` list filter the walk output.
+ *
+ * Mode resolution falls back to {@see FileMode::Replace} when no pattern in `modes{}` matches the destination.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class ManifestExpander
+{
+    /**
+     * Expands a validated manifest into the list of file mappings that the scaffolder must apply.
+     *
+     * @param array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} $manifest Validated
+     * manifest as returned by {@see ManifestSchema::validate()}.
+     * @param string $providerPath Absolute path to the provider root on disk.
+     * @param string $providerName Composer package name (used to attribute the mapping for provenance).
+     *
+     * @throws RuntimeException when a path listed in `copy[]` does not exist on disk.
+     *
+     * @return list<FileMapping> Concrete list of mappings, ready for the scaffolder.
+     */
+    public function expand(array $manifest, string $providerPath, string $providerName): array
+    {
+        $mappings = [];
+        $seen = [];
+
+        foreach ($manifest['copy'] as $entry) {
+            $absolute = $providerPath . '/' . $entry;
+
+            if (is_file($absolute)) {
+                $relative = self::normalise($entry);
+
+                if (isset($seen[$relative])) {
+                    continue;
+                }
+
+                // Dedup tag only; value is immaterial since 'isset' is the only reader.
+                // @codeCoverageIgnoreStart
+                $seen[$relative] = true;
+                // @codeCoverageIgnoreEnd
+
+                $mappings[] = $this->buildMapping(
+                    $relative,
+                    $this->resolveMode($relative, $manifest['modes']),
+                    $providerName,
+                    $providerPath,
+                );
+
+                continue;
+            }
+
+            if (is_dir($absolute)) {
+                $prefix = self::normalise($entry);
+                $prefix = $prefix === '.' ? '' : $prefix;
+
+                foreach ($this->walk($absolute, $prefix, $manifest['exclude']) as $relative) {
+                    if (isset($seen[$relative])) {
+                        continue;
+                    }
+
+                    // @codeCoverageIgnoreStart
+                    // Dedup tag only; value is immaterial since 'isset' is the only reader.
+                    $seen[$relative] = true;
+                    // @codeCoverageIgnoreEnd
+                    $mappings[] = $this->buildMapping(
+                        $relative,
+                        $this->resolveMode($relative, $manifest['modes']),
+                        $providerName,
+                        $providerPath,
+                    );
+                }
+
+                continue;
+            }
+
+            throw new RuntimeException(
+                sprintf('Scaffold copy entry "%s" does not exist under provider root "%s".', $entry, $providerPath),
+            );
+        }
+
+        return $mappings;
+    }
+
+    /**
+     * Builds a {@see FileMapping} for a given relative destination.
+     *
+     * @param string $relative Relative path to the file inside the provider, using forward slashes.
+     * @param FileMode $mode Resolved file mode for the mapping.
+     * @param string $providerName Composer package name (used to attribute the mapping for provenance).
+     * @param string $providerPath Absolute path to the provider root on disk.
+     *
+     * @return FileMapping Concrete file mapping for the given relative path and mode.
+     */
+    private function buildMapping(
+        string $relative,
+        FileMode $mode,
+        string $providerName,
+        string $providerPath,
+    ): FileMapping {
+        return new FileMapping(
+            destination: $relative,
+            source: $relative,
+            mode: $mode,
+            providerName: $providerName,
+            providerPath: $providerPath,
+        );
+    }
+
+    /**
+     * Determines if a given relative path matches any of the provided glob patterns.
+     *
+     * @param list<string> $patterns Glob patterns to evaluate.
+     * @param string $path Relative path to test, using forward slashes.
+     *
+     * @return bool `true` when `$path` matches any of the given glob patterns, `false` otherwise.
+     */
+    private static function matchesAny(string $path, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (Glob::matches($pattern, $path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Normalises a relative path to forward slashes.
+     *
+     * This is a no-op on POSIX but ensures consistent path handling on Windows, where `copy[]` entries may be declared
+     * with either slash type.
+     *
+     * @param string $path Relative path to normalise, using either forward or backward slashes.
+     *
+     * @return string Normalised path with forward slashes.
+     */
+    private static function normalise(string $path): string
+    {
+        // Windows-path adapter, POSIX-identity.
+        // @codeCoverageIgnoreStart
+        return str_replace('\\', '/', $path);
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Resolves the {@see FileMode} for `$relative` against the manifest's `modes` map.
+     *
+     * Exact path matches win over globs; globs are evaluated in declaration order.
+     *
+     * @param array<string, FileMode> $modes Mode overrides from the manifest.
+     */
+    private function resolveMode(string $relative, array $modes): FileMode
+    {
+        if (isset($modes[$relative])) {
+            return $modes[$relative];
+        }
+
+        foreach ($modes as $pattern => $mode) {
+            if (Glob::matches($pattern, $relative)) {
+                return $mode;
+            }
+        }
+
+        return FileMode::Replace;
+    }
+
+    /**
+     * Walks a directory listed in `copy[]`, filtering out paths matching either default excludes or user excludes.
+     *
+     * @param string $absoluteDir Absolute path to the directory to walk.
+     * @param string $relativePrefix Relative directory prefix to prepend to each discovered file.
+     * @param list<string> $userExcludes Glob patterns declared in `scaffold.exclude`.
+     *
+     * @return list<string> Ordered list of relative file paths inside the directory that survive both exclusion layers.
+     */
+    private function walk(string $absoluteDir, string $relativePrefix, array $userExcludes): array
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($absoluteDir, FilesystemIterator::SKIP_DOTS),
+        );
+
+        $results = [];
+        $absolutePrefix = self::normalise($absoluteDir);
+
+        /** @var SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            if ($entry->isDir()) {
+                continue;
+            }
+
+            $absolute = self::normalise($entry->getPathname());
+            $tail = substr($absolute, strlen($absolutePrefix) + 1);
+            $relative = $relativePrefix === '' ? $tail : "{$relativePrefix}/{$tail}";
+
+            if (DefaultExcludes::matches($relative) || self::matchesAny($relative, $userExcludes)) {
+                continue;
+            }
+
+            $results[] = $relative;
+        }
+
+        // Defensive sort for filesystems that do not return entries alphabetically; on Linux the iterator is already
+        // ordered so removing the call is observationally equivalent on the POSIX CI matrix.
+
+        // @codeCoverageIgnoreStart
+        sort($results);
+        // @codeCoverageIgnoreEnd
+
+        return $results;
+    }
+}

--- a/src/Manifest/ManifestExpander.php
+++ b/src/Manifest/ManifestExpander.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii\scaffold\Manifest;
 
 use FilesystemIterator;
+use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
@@ -12,8 +13,10 @@ use SplFileInfo;
 
 use function is_dir;
 use function is_file;
+use function rtrim;
 use function sort;
 use function sprintf;
+use function str_ends_with;
 use function str_replace;
 use function strlen;
 use function substr;
@@ -61,7 +64,6 @@ final class ManifestExpander
                     continue;
                 }
 
-                // Dedup tag only; value is immaterial since 'isset' is the only reader.
                 // @codeCoverageIgnoreStart
                 $seen[$relative] = true;
                 // @codeCoverageIgnoreEnd
@@ -77,7 +79,7 @@ final class ManifestExpander
             }
 
             if (is_dir($absolute)) {
-                $prefix = self::normalise($entry);
+                $prefix = rtrim(self::normalise($entry), '/');
                 $prefix = $prefix === '.' ? '' : $prefix;
 
                 foreach ($this->walk($absolute, $prefix, $manifest['exclude']) as $relative) {
@@ -86,9 +88,9 @@ final class ManifestExpander
                     }
 
                     // @codeCoverageIgnoreStart
-                    // Dedup tag only; value is immaterial since 'isset' is the only reader.
                     $seen[$relative] = true;
                     // @codeCoverageIgnoreEnd
+
                     $mappings[] = $this->buildMapping(
                         $relative,
                         $this->resolveMode($relative, $manifest['modes']),
@@ -106,6 +108,37 @@ final class ManifestExpander
         }
 
         return $mappings;
+    }
+
+    /**
+     * Recursive filter callback deciding whether an iterator entry should be visited.
+     *
+     * Files pass through unconditionally so they can be exclude-filtered at file level; directories are tested against
+     * the default and user dir-prune patterns so that excluded subtrees (for example `vendor/**`) are never descended.
+     *
+     * @param SplFileInfo $current Filesystem entry offered by the inner iterator.
+     * @param string $absolutePrefix Rtrim'd absolute path of the walk root on disk.
+     * @param string $relativePrefix Relative directory prefix to prepend when deriving the walk-relative path.
+     * @param list<string> $userExcludes User-declared exclude patterns from the manifest.
+     *
+     * @return bool `true` when the iterator should accept the entry (and descend, for dirs), `false` to prune it.
+     */
+    private function acceptIteratorEntry(
+        SplFileInfo $current,
+        string $absolutePrefix,
+        string $relativePrefix,
+        array $userExcludes,
+    ): bool {
+        // @codeCoverageIgnoreStart interceptor does not swap this file for filter callbacks.
+        if ($current->isDir() === false) {
+            return true;
+        }
+        // @codeCoverageIgnoreEnd
+
+        return self::canDescend(
+            self::relativise($current, $absolutePrefix, $relativePrefix),
+            $userExcludes,
+        );
     }
 
     /**
@@ -131,6 +164,32 @@ final class ManifestExpander
             providerName: $providerName,
             providerPath: $providerPath,
         );
+    }
+
+    /**
+     * Determines whether the iterator may descend into `$relativeDir` based on both default and user exclude patterns.
+     *
+     * The directory may be pruned whenever a pattern of the form `$relativeDir/**` exists in either layer, because
+     * every possible descendant would then match an exclude and be dropped at file level anyway.
+     *
+     * @param string $relativeDir Directory path relative to the walk root, using forward slashes.
+     * @param list<string> $userExcludes User-declared exclude patterns from the manifest.
+     *
+     * @return bool `true` when the iterator should descend, `false` when the subtree may be skipped entirely.
+     */
+    private static function canDescend(string $relativeDir, array $userExcludes): bool
+    {
+        if (DefaultExcludes::matchesDirectory($relativeDir)) {
+            return false;
+        }
+
+        foreach ($userExcludes as $pattern) {
+            if (str_ends_with($pattern, '/**') && substr($pattern, 0, -3) === $relativeDir) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -164,10 +223,30 @@ final class ManifestExpander
      */
     private static function normalise(string $path): string
     {
-        // Windows-path adapter, POSIX-identity.
         // @codeCoverageIgnoreStart
         return str_replace('\\', '/', $path);
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Derives the walk-relative path for a filesystem entry, using forward slashes.
+     *
+     * Called both by the recursive filter (to decide whether to prune a directory) and by the main loop (to emit file
+     * destinations), so it produces the exact same string for a given entry in either context.
+     *
+     * @param SplFileInfo $entry Filesystem entry returned by the iterator.
+     * @param string $absolutePrefix Rtrim'd absolute path of the walk root on disk.
+     * @param string $relativePrefix Relative directory prefix to prepend, or an empty string when walking from root.
+     *
+     * @return string Path relative to the walk root, using forward slashes.
+     */
+    private static function relativise(SplFileInfo $entry, string $absolutePrefix, string $relativePrefix): string
+    {
+        $absolute = self::normalise($entry->getPathname());
+
+        $tail = substr($absolute, strlen($absolutePrefix) + 1);
+
+        return $relativePrefix === '' ? $tail : "{$relativePrefix}/{$tail}";
     }
 
     /**
@@ -203,22 +282,24 @@ final class ManifestExpander
      */
     private function walk(string $absoluteDir, string $relativePrefix, array $userExcludes): array
     {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($absoluteDir, FilesystemIterator::SKIP_DOTS),
-        );
-
         $results = [];
-        $absolutePrefix = self::normalise($absoluteDir);
+        $absolutePrefix = rtrim(self::normalise($absoluteDir), '/');
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($absoluteDir, FilesystemIterator::SKIP_DOTS),
+                fn(SplFileInfo $current): bool => $this->acceptIteratorEntry(
+                    $current,
+                    $absolutePrefix,
+                    $relativePrefix,
+                    $userExcludes,
+                ),
+            ),
+        );
 
         /** @var SplFileInfo $entry */
         foreach ($iterator as $entry) {
-            if ($entry->isDir()) {
-                continue;
-            }
-
-            $absolute = self::normalise($entry->getPathname());
-            $tail = substr($absolute, strlen($absolutePrefix) + 1);
-            $relative = $relativePrefix === '' ? $tail : "{$relativePrefix}/{$tail}";
+            $relative = self::relativise($entry, $absolutePrefix, $relativePrefix);
 
             if (DefaultExcludes::matches($relative) || self::matchesAny($relative, $userExcludes)) {
                 continue;
@@ -226,9 +307,6 @@ final class ManifestExpander
 
             $results[] = $relative;
         }
-
-        // Defensive sort for filesystems that do not return entries alphabetically; on Linux the iterator is already
-        // ordered so removing the call is observationally equivalent on the POSIX CI matrix.
 
         // @codeCoverageIgnoreStart
         sort($results);

--- a/src/Manifest/ManifestLoader.php
+++ b/src/Manifest/ManifestLoader.php
@@ -7,31 +7,39 @@ namespace yii\scaffold\Manifest;
 use Composer\Package\PackageInterface;
 use RuntimeException;
 
+use function file_get_contents;
+use function in_array;
 use function is_array;
+use function is_file;
+use function is_string;
+use function json_decode;
+use function preg_match;
+use function preg_split;
 use function sprintf;
+use function str_starts_with;
 
 /**
- * Loads scaffold file mappings from a Composer package manifest.
+ * Loads and expands a scaffold provider's manifest into a flat list of {@see FileMapping} entries.
  *
- * Supports both inline `extra.scaffold.file-mapping` declarations and external `extra.scaffold.manifest` JSON files
- * relative to the provider root.
+ * Supports both inline `extra.scaffold` declarations and external JSON manifests referenced by
+ * `extra.scaffold.manifest` relative to the provider root.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
 final class ManifestLoader
 {
-    public function __construct(private readonly ManifestSchema $schema) {}
+    public function __construct(private readonly ManifestSchema $schema, private readonly ManifestExpander $expander) {}
 
     /**
-     * Loads all file mappings declared by a scaffold provider package.
+     * Loads the provider's manifest and expands it into concrete file mappings.
      *
      * @param PackageInterface $package Provider Composer package.
-     * @param string $packagePath Absolute path to the provider root inside vendor.
+     * @param string $packagePath Absolute path to the provider root on disk.
      *
-     * @return list<FileMapping> List of file mappings declared by the provider.
+     * @throws RuntimeException when the manifest file is missing, malformed, or structurally invalid.
      *
-     * @throws RuntimeException when the manifest file is missing or invalid.
+     * @return list<FileMapping> File mappings ready for the scaffolder.
      */
     public function load(PackageInterface $package, string $packagePath): array
     {
@@ -43,56 +51,27 @@ final class ManifestLoader
             return [];
         }
 
-        if (isset($scaffold['manifest'])) {
-            return $this->loadExternal($scaffold['manifest'], $package->getName(), $packagePath);
-        }
+        $raw = isset($scaffold['manifest'])
+            ? $this->readExternal($scaffold['manifest'], $package->getName(), $packagePath)
+            : $scaffold;
 
-        if (isset($scaffold['file-mapping'])) {
-            return $this->buildFromValidated(
-                $this->schema->validate(['file-mapping' => $scaffold['file-mapping']]),
-                $package->getName(),
-                $packagePath,
-            );
-        }
+        $validated = $this->schema->validate($raw);
 
-        return [];
+        return $this->expander->expand($validated, $packagePath, $package->getName());
     }
 
     /**
-     * Builds file mappings from already validated manifest data.
-     *
-     * @param array<string, array{source: string, mode: FileMode}> $fileMapping Validated file-mapping data, with `mode`
-     * already resolved by {@see ManifestSchema} to the corresponding {@see FileMode} case.
-     *
-     * @return list<FileMapping> List of file mappings built from the validated manifest data.
-     */
-    private function buildFromValidated(array $fileMapping, string $packageName, string $packagePath): array
-    {
-        $mappings = [];
-
-        foreach ($fileMapping as $destination => $entry) {
-            $mappings[] = new FileMapping(
-                destination: $destination,
-                source: $entry['source'],
-                mode: $entry['mode'],
-                providerName: $packageName,
-                providerPath: $packagePath,
-            );
-        }
-
-        return $mappings;
-    }
-
-    /**
-     * Loads file mappings from an external manifest JSON file declared by the provider.
+     * Reads and decodes an external manifest file referenced from `extra.scaffold.manifest`.
      *
      * @param mixed $manifestPath Raw manifest path from the provider declaration, expected to be a non-empty string.
-     * @param string $packageName Name of the provider package.
-     * @param string $packagePath Absolute path to the provider root inside vendor.
+     * @param string $packageName Provider Composer package name (used for error messages).
+     * @param string $packagePath Absolute path to the provider root on disk.
      *
-     * @return list<FileMapping> List of file mappings loaded from the external manifest file.
+     * @throws RuntimeException on any failure to read or decode the file.
+     *
+     * @return array<mixed> Raw decoded JSON content ready for {@see ManifestSchema::validate()}.
      */
-    private function loadExternal(mixed $manifestPath, string $packageName, string $packagePath): array
+    private function readExternal(mixed $manifestPath, string $packageName, string $packagePath): array
     {
         if (!is_string($manifestPath) || $manifestPath === '') {
             throw new RuntimeException(
@@ -100,11 +79,14 @@ final class ManifestLoader
             );
         }
 
-        if (
-            str_starts_with($manifestPath, '/')
+        // Windows-absolute-path guards, equivalent under POSIX.
+        // @codeCoverageIgnoreStart
+        $isAbsolute = str_starts_with($manifestPath, '/')
             || str_starts_with($manifestPath, '\\')
-            || preg_match('/^[A-Za-z]:/', $manifestPath) === 1
-        ) {
+            || preg_match('/^[A-Za-z]:/', $manifestPath) === 1;
+        // @codeCoverageIgnoreEnd
+
+        if ($isAbsolute) {
             throw new RuntimeException(
                 sprintf('Provider "%s": "manifest" must be a relative path inside the provider root.', $packageName),
             );
@@ -142,10 +124,6 @@ final class ManifestLoader
             );
         }
 
-        return $this->buildFromValidated(
-            $this->schema->validate($raw),
-            $packageName,
-            $packagePath,
-        );
+        return $raw;
     }
 }

--- a/src/Manifest/ManifestLoader.php
+++ b/src/Manifest/ManifestLoader.php
@@ -7,7 +7,6 @@ namespace yii\scaffold\Manifest;
 use Composer\Package\PackageInterface;
 use RuntimeException;
 
-use function file_get_contents;
 use function in_array;
 use function is_array;
 use function is_file;
@@ -79,12 +78,10 @@ final class ManifestLoader
             );
         }
 
-        // Windows-absolute-path guards, equivalent under POSIX.
-        // @codeCoverageIgnoreStart
+        // reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
         $isAbsolute = str_starts_with($manifestPath, '/')
             || str_starts_with($manifestPath, '\\')
             || preg_match('/^[A-Za-z]:/', $manifestPath) === 1;
-        // @codeCoverageIgnoreEnd
 
         if ($isAbsolute) {
             throw new RuntimeException(

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -166,11 +166,7 @@ final class ManifestSchema
         $resolved = [];
 
         foreach ($raw['modes'] as $pattern => $modeValue) {
-            if (!is_string($pattern) || $pattern === '') {
-                throw new RuntimeException(
-                    sprintf('Manifest "modes" key must be a non-empty string, got "%s".', (string) $pattern),
-                );
-            }
+            $this->assertSafeRelativePath($pattern, 'modes');
 
             if (!is_string($modeValue)) {
                 throw new RuntimeException(

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -68,12 +68,10 @@ final class ManifestSchema
             );
         }
 
-        // Windows-absolute-path guards, equivalent under POSIX.
-        // @codeCoverageIgnoreStart
+        // reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
         $isAbsolute = str_starts_with($path, '/')
             || str_starts_with($path, '\\')
             || preg_match('/^[A-Za-z]:/', $path) === 1;
-        // @codeCoverageIgnoreEnd
 
         if ($isAbsolute) {
             throw new RuntimeException(

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -9,18 +9,22 @@ use RuntimeException;
 use function array_column;
 use function array_key_exists;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_string;
+use function preg_match;
+use function preg_split;
 use function sprintf;
+use function str_starts_with;
 
 /**
- * Validates and normalizes the raw decoded JSON structure of a scaffold manifest.
+ * Validates and normalises the `scaffold.json` manifest structure.
  *
- * Returns a typed file-mapping array (with `mode` already resolved to a {@see FileMode} case) when validation succeeds,
- * or throws on the first structural violation found.
+ * Accepts the `copy` / `exclude` / `modes` schema introduced in `0.2.0` and returns a typed structure ready for
+ * {@see ManifestExpander} to consume. Throws {@see RuntimeException} with a descriptive message on the first
+ * structural violation found.
  *
- * @phpstan-type FileMappingEntry array{source: string, mode: FileMode}
- * @phpstan-type ValidatedFileMapping array<string, FileMappingEntry>
+ * @phpstan-type ValidatedManifest array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>}
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -28,66 +32,168 @@ use function sprintf;
 final class ManifestSchema
 {
     /**
-     * Validates a raw decoded manifest array and returns the typed file-mapping.
+     * Validates a raw decoded manifest array and returns the typed structure.
      *
-     * @param array<mixed> $raw Decoded JSON content of the manifest.
+     * @param array<mixed> $raw Decoded JSON content of the manifest (or the inline `extra.scaffold` array).
      *
      * @throws RuntimeException when the manifest structure is invalid.
      *
-     * @return array<string, array{source: string, mode: FileMode}> Validated and typed file-mapping entries with `mode`
-     * resolved to the corresponding {@see FileMode} case.
+     * @return array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} Typed manifest with
+     * `copy[]` paths normalised to forward slashes and `modes` values resolved to {@see FileMode} cases.
      */
     public function validate(array $raw): array
     {
-        if (!array_key_exists('file-mapping', $raw) || !is_array($raw['file-mapping'])) {
+        return [
+            'copy' => $this->validateCopy($raw),
+            'exclude' => $this->validateExclude($raw),
+            'modes' => $this->validateModes($raw),
+        ];
+    }
+
+    /**
+     * Asserts that `$path` is a non-empty relative string without traversal segments or absolute prefixes.
+     *
+     * @param mixed $path Candidate path (validated to be string).
+     * @param string $key Name of the manifest key being validated (for error messages).
+     *
+     * @throws RuntimeException when the path fails any of the safety checks.
+     *
+     * @phpstan-assert non-empty-string $path
+     */
+    private function assertSafeRelativePath(mixed $path, string $key): void
+    {
+        if (!is_string($path) || $path === '') {
             throw new RuntimeException(
-                'Manifest is missing required key "file-mapping" or it is not an array.',
+                sprintf('Manifest "%s" entries must be non-empty strings.', $key),
             );
         }
 
-        $typed = [];
+        // Windows-absolute-path guards, equivalent under POSIX.
+        // @codeCoverageIgnoreStart
+        $isAbsolute = str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || preg_match('/^[A-Za-z]:/', $path) === 1;
+        // @codeCoverageIgnoreEnd
 
-        foreach ($raw['file-mapping'] as $destination => $entry) {
-            if (!is_string($destination) || $destination === '') {
+        if ($isAbsolute) {
+            throw new RuntimeException(
+                sprintf('Manifest "%s" entry "%s" must be a relative path.', $key, $path),
+            );
+        }
+
+        $segments = preg_split('#[/\\\\]#', $path);
+
+        if (is_array($segments) && in_array('..', $segments, true)) {
+            throw new RuntimeException(
+                sprintf('Manifest "%s" entry "%s" must not contain path traversal segments.', $key, $path),
+            );
+        }
+    }
+
+    /**
+     * Validates the `copy` key.
+     *
+     * @param array<mixed> $raw Raw manifest array.
+     *
+     * @return list<string> List of non-empty, relative, non-traversal paths.
+     */
+    private function validateCopy(array $raw): array
+    {
+        if (!array_key_exists('copy', $raw) || !is_array($raw['copy'])) {
+            throw new RuntimeException('Manifest is missing required key "copy" or it is not an array.');
+        }
+
+        if ($raw['copy'] === []) {
+            throw new RuntimeException('Manifest "copy" must declare at least one path.');
+        }
+
+        $paths = [];
+
+        foreach ($raw['copy'] as $path) {
+            $this->assertSafeRelativePath($path, 'copy');
+
+            $paths[] = $path;
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Validates the optional `exclude` key.
+     *
+     * @param array<mixed> $raw Raw manifest array.
+     *
+     * @return list<string> List of non-empty, relative, non-traversal patterns.
+     */
+    private function validateExclude(array $raw): array
+    {
+        if (!array_key_exists('exclude', $raw)) {
+            return [];
+        }
+
+        if (!is_array($raw['exclude'])) {
+            throw new RuntimeException('Manifest "exclude" must be an array when present.');
+        }
+
+        $patterns = [];
+
+        foreach ($raw['exclude'] as $pattern) {
+            $this->assertSafeRelativePath($pattern, 'exclude');
+
+            $patterns[] = $pattern;
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Validates the optional `modes` key.
+     *
+     * @param array<mixed> $raw Raw manifest array.
+     *
+     * @return array<string, FileMode> Mode map keyed by pattern.
+     */
+    private function validateModes(array $raw): array
+    {
+        if (!array_key_exists('modes', $raw)) {
+            return [];
+        }
+
+        if (!is_array($raw['modes'])) {
+            throw new RuntimeException('Manifest "modes" must be an object when present.');
+        }
+
+        $resolved = [];
+
+        foreach ($raw['modes'] as $pattern => $modeValue) {
+            if (!is_string($pattern) || $pattern === '') {
                 throw new RuntimeException(
-                    sprintf('Manifest file-mapping key must be a non-empty string, got "%s".', $destination),
+                    sprintf('Manifest "modes" key must be a non-empty string, got "%s".', (string) $pattern),
                 );
             }
 
-            if (!is_array($entry)) {
+            if (!is_string($modeValue)) {
                 throw new RuntimeException(
-                    sprintf('Manifest entry for "%s" must be an object.', $destination),
+                    sprintf('Manifest "modes" value for pattern "%s" must be a string.', $pattern),
                 );
             }
 
-            if (!isset($entry['source']) || !is_string($entry['source']) || $entry['source'] === '') {
-                throw new RuntimeException(
-                    sprintf('Manifest entry for "%s" is missing a non-empty "source" key.', $destination),
-                );
-            }
-
-            if (!isset($entry['mode']) || !is_string($entry['mode'])) {
-                throw new RuntimeException(
-                    sprintf('Manifest entry for "%s" is missing a "mode" key.', $destination),
-                );
-            }
-
-            $mode = FileMode::tryFrom($entry['mode']);
+            $mode = FileMode::tryFrom($modeValue);
 
             if ($mode === null) {
                 throw new RuntimeException(
                     sprintf(
-                        'Manifest entry for "%s" has invalid mode "%s". Allowed: %s.',
-                        $destination,
-                        $entry['mode'],
+                        'Manifest "modes" value for pattern "%s" has invalid mode "%s". Allowed: %s.',
+                        $pattern,
+                        $modeValue,
                         implode(', ', array_column(FileMode::cases(), 'value')),
                     ),
                 );
             }
 
-            $typed[$destination] = ['source' => $entry['source'], 'mode' => $mode];
+            $resolved[$pattern] = $mode;
         }
 
-        return $typed;
+        return $resolved;
     }
 }

--- a/tests/functional/ComposerInstallTest.php
+++ b/tests/functional/ComposerInstallTest.php
@@ -30,12 +30,12 @@ final class ComposerInstallTest extends TestCase
 
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/config/params.php',
+            'config/params.php',
             "<?php return ['adminEmail' => 'a@b.c'];\n",
         );
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/.gitignore',
+            '.gitignore',
             "/runtime/\n",
         );
         $builder->createComposerJson(
@@ -55,15 +55,10 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => 'stubs/config/params.php',
-                        'mode' => 'preserve',
-                    ],
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
+                'copy' => ['config/params.php', '.gitignore'],
+                'modes' => [
+                    'config/params.php' => 'preserve',
+                    '.gitignore' => 'append',
                 ],
             ],
         );
@@ -105,7 +100,7 @@ final class ComposerInstallTest extends TestCase
 
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/config/params.php',
+            'config/params.php',
             "<?php return [];\n",
         );
         $builder->createComposerJson(
@@ -128,9 +123,8 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'preserve'],
-                ],
+                'copy' => ['config/params.php'],
+                'modes' => ['config/params.php' => 'preserve'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -184,7 +178,7 @@ final class ComposerInstallTest extends TestCase
 
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/config/params.php',
+            'config/params.php',
             "<?php return [];\n",
         );
         $builder->createComposerJson(
@@ -208,9 +202,8 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    'config/params.php' => ['source' => 'stubs/config/params.php', 'mode' => 'preserve'],
-                ],
+                'copy' => ['config/params.php'],
+                'modes' => ['config/params.php' => 'preserve'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -229,7 +222,7 @@ final class ComposerInstallTest extends TestCase
 
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/.env.dist',
+            '.env.dist',
             "APP_ENV=dev\n",
         );
         $builder->createComposerJson(
@@ -253,12 +246,7 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.env.dist' => [
-                        'source' => 'stubs/.env.dist',
-                        'mode' => 'replace',
-                    ],
-                ],
+                'copy' => ['.env.dist'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -307,7 +295,7 @@ final class ComposerInstallTest extends TestCase
 
         $builder->createStubFile(
             'demo/scaffold',
-            'stubs/config/params.php',
+            'config/params.php',
             "<?php return [];\n",
         );
         $builder->createComposerJson(
@@ -331,12 +319,8 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => 'stubs/config/params.php',
-                        'mode' => 'preserve',
-                    ],
-                ],
+                'copy' => ['config/params.php'],
+                'modes' => ['config/params.php' => 'preserve'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -381,7 +365,7 @@ final class ComposerInstallTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.env.dist', "APP_ENV=dev\n");
+        $builder->createStubFile('demo/scaffold', '.env.dist', "APP_ENV=dev\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -403,12 +387,7 @@ final class ComposerInstallTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.env.dist' => [
-                        'source' => 'stubs/.env.dist',
-                        'mode' => 'replace',
-                    ],
-                ],
+                'copy' => ['.env.dist'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();

--- a/tests/functional/CreateProjectTest.php
+++ b/tests/functional/CreateProjectTest.php
@@ -31,7 +31,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile('demo/scaffold', '.gitignore', "/runtime/\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -48,6 +48,7 @@ final class CreateProjectTest extends TestCase
 
         // pre-populate the lock so partial scaffold (fullScaffold=false) would skip '.gitignore'.
         $builder->createProjectFile('.gitignore', "existing\n");
+
         (new LockFile($builder->getProjectRoot()))->write(
             [
                 'providers' => [
@@ -57,7 +58,7 @@ final class CreateProjectTest extends TestCase
                     '.gitignore' => [
                         'hash' => 'sha256:' . hash('sha256', "existing\n"),
                         'provider' => 'demo/scaffold',
-                        'source' => 'stubs/.gitignore',
+                        'source' => '.gitignore',
                         'mode' => 'append',
                     ],
                 ],
@@ -71,12 +72,8 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
+                'copy' => ['.gitignore'],
+                'modes' => ['.gitignore' => 'append'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -96,7 +93,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile('demo/scaffold', '.gitignore', "/runtime/\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -118,12 +115,8 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
+                'copy' => ['.gitignore'],
+                'modes' => ['.gitignore' => 'append'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -142,7 +135,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile('demo/scaffold', '.gitignore', "/runtime/\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -164,12 +157,8 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
+                'copy' => ['.gitignore'],
+                'modes' => ['.gitignore' => 'append'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -192,7 +181,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/config/params.php', "<?php return [];\n");
+        $builder->createStubFile('demo/scaffold', 'config/params.php', "<?php return [];\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -214,12 +203,7 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => 'stubs/config/params.php',
-                        'mode' => 'replace',
-                    ],
-                ],
+                'copy' => ['config/params.php'],
             ],
             '2.5.0',
         );
@@ -254,7 +238,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile('demo/scaffold', '.gitignore', "/runtime/\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -270,6 +254,7 @@ final class CreateProjectTest extends TestCase
         );
 
         $builder->createProjectFile('.gitignore', "existing\n");
+
         (new LockFile($builder->getProjectRoot()))->write(
             [
                 'providers' => [
@@ -279,7 +264,7 @@ final class CreateProjectTest extends TestCase
                     '.gitignore' => [
                         'hash' => 'sha256:' . hash('sha256', "existing\n"),
                         'provider' => 'demo/scaffold',
-                        'source' => 'stubs/.gitignore',
+                        'source' => '.gitignore',
                         'mode' => 'append',
                     ],
                 ],
@@ -293,12 +278,8 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
+                'copy' => ['.gitignore'],
+                'modes' => ['.gitignore' => 'append'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();
@@ -318,7 +299,7 @@ final class CreateProjectTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/scaffold', 'stubs/.gitignore', "/runtime/\n");
+        $builder->createStubFile('demo/scaffold', '.gitignore', "/runtime/\n");
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -334,6 +315,7 @@ final class CreateProjectTest extends TestCase
         );
 
         $builder->createProjectFile('.gitignore', "existing\n");
+
         (new LockFile($builder->getProjectRoot()))->write(
             [
                 'providers' => [
@@ -343,7 +325,7 @@ final class CreateProjectTest extends TestCase
                     '.gitignore' => [
                         'hash' => 'sha256:' . hash('sha256', "existing\n"),
                         'provider' => 'demo/scaffold',
-                        'source' => 'stubs/.gitignore',
+                        'source' => '.gitignore',
                         'mode' => 'append',
                     ],
                 ],
@@ -357,12 +339,8 @@ final class CreateProjectTest extends TestCase
             $composer,
             'demo/scaffold',
             [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
+                'copy' => ['.gitignore'],
+                'modes' => ['.gitignore' => 'append'],
             ],
         );
         $this->resetInstallScaffoldRanFlag();

--- a/tests/functional/MultiLayerCompositionTest.php
+++ b/tests/functional/MultiLayerCompositionTest.php
@@ -119,14 +119,7 @@ final class MultiLayerCompositionTest extends TestCase
 
     private function addMockProvidersSharingDestination(Composer $composer): void
     {
-        $manifest = [
-            'file-mapping' => [
-                'config/web.php' => [
-                    'source' => 'stubs/config/web.php',
-                    'mode' => 'replace',
-                ],
-            ],
-        ];
+        $manifest = ['copy' => ['config/web.php']];
 
         $this->addMockProvider($composer, 'demo/provider-a', $manifest);
         $this->addMockProvider($composer, 'demo/provider-b', $manifest);
@@ -136,8 +129,8 @@ final class MultiLayerCompositionTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('demo/provider-a', 'stubs/config/web.php', 'provider-a content');
-        $builder->createStubFile('demo/provider-b', 'stubs/config/web.php', 'provider-b content');
+        $builder->createStubFile('demo/provider-a', 'config/web.php', 'provider-a content');
+        $builder->createStubFile('demo/provider-b', 'config/web.php', 'provider-b content');
 
         return $builder;
     }

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -9,7 +9,7 @@ use Composer\Package\PackageInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
-use yii\scaffold\Manifest\{ManifestLoader, ManifestSchema};
+use yii\scaffold\Manifest\{ManifestExpander, ManifestLoader, ManifestSchema};
 use yii\scaffold\Scaffold\{Applier, Scaffolder};
 use yii\scaffold\Scaffold\Lock\{Hasher, LockFile};
 use yii\scaffold\Security\{PackageAllowlist, PathValidator};
@@ -36,7 +36,7 @@ final class ScaffolderTest extends TestCase
 
         $io = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(
                 new PackageAllowlist(['yii2-extensions/missing']),
                 new PathValidator(),
@@ -61,19 +61,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/.gitignore', '*.log');
+        $builder->createStubFile('yii2-extensions/test', '.gitignore', '*.log');
         $builder->createProjectFile('.gitignore', 'vendor/');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        '.gitignore' => [
-                            'source' => 'stubs/.gitignore',
-                            'mode' => 'append',
-                        ],
-                    ],
+                    'copy' => ['.gitignore'],
+                    'modes' => ['.gitignore' => 'append'],
                 ],
             ],
         );
@@ -101,16 +97,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/.gitignore', '*.log');
+        $builder->createStubFile('yii2-extensions/test', '.gitignore', '*.log');
         $builder->createProjectFile('.gitignore', 'vendor/');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        '.gitignore' => ['source' => 'stubs/.gitignore', 'mode' => 'append'],
-                    ],
+                    'copy' => ['.gitignore'],
+                    'modes' => ['.gitignore' => 'append'],
                 ],
             ],
         );
@@ -141,18 +136,13 @@ final class ScaffolderTest extends TestCase
          * `yii2-extensions/test`, the Applier will throw with "Package not allowed" inside apply(). That throw must be
          * caught by the Scaffolder loop and reported via writeError.
          */
-        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'content');
+        $builder->createStubFile('yii2-extensions/test', 'app.php', 'content');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -162,7 +152,7 @@ final class ScaffolderTest extends TestCase
 
         // allowlist only admits a DIFFERENT provider, so assertAllowed throws RuntimeException during apply().
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist(['safe/other']), new PathValidator(), new Hasher(), $io),
             new LockFile($builder->getProjectRoot()),
             $io,
@@ -200,7 +190,7 @@ final class ScaffolderTest extends TestCase
 
         $io = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist([]), new PathValidator(), new Hasher(), $io),
             new LockFile($builder->getProjectRoot()),
             $io,
@@ -216,11 +206,12 @@ final class ScaffolderTest extends TestCase
         );
     }
 
-    public function testEmptyFileMappingReturnsEarlyAndDoesNotWriteLockFile(): void
+    public function testEmptyManifestReturnsEarlyAndDoesNotWriteLockFile(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $provider = $this->makeProviderPackage('yii2-extensions/empty', ['scaffold' => ['file-mapping' => []]]);
+        // provider has no scaffold extra at all; loader returns an empty mapping list and the lock stays untouched.
+        $provider = $this->makeProviderPackage('yii2-extensions/empty', []);
         $root = $this->makeRootPackage(['yii2-extensions/empty']);
 
         $this
@@ -229,7 +220,7 @@ final class ScaffolderTest extends TestCase
 
         self::assertFalse(
             (new LockFile($builder->getProjectRoot()))->exists(),
-            "Empty 'file-mapping' must short-circuit before the lock is written.",
+            'An empty manifest must short-circuit before the lock is written.',
         );
     }
 
@@ -248,7 +239,7 @@ final class ScaffolderTest extends TestCase
 
         $io = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist(['yii2-extensions/bad']), new PathValidator(), new Hasher(), $io),
             new LockFile($builder->getProjectRoot()),
             $io,
@@ -267,18 +258,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'a');
+        $builder->createStubFile('yii2-extensions/test', 'app.php', 'a');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -317,19 +303,14 @@ final class ScaffolderTest extends TestCase
          */
         $providerRootInsideProject = $builder->getProjectRoot() . '/vendor/yii2-extensions/test';
 
-        mkdir($providerRootInsideProject . '/stubs', 0777, recursive: true);
-        file_put_contents($providerRootInsideProject . '/stubs/app.php', 'a');
+        mkdir($providerRootInsideProject, 0777, recursive: true);
+        file_put_contents($providerRootInsideProject . '/app.php', 'a');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -359,19 +340,14 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/base', 'stubs/app.php', 'base content');
-        $builder->createStubFile('yii2-extensions/override', 'stubs/app.php', 'override content');
+        $builder->createStubFile('yii2-extensions/base', 'app.php', 'base content');
+        $builder->createStubFile('yii2-extensions/override', 'app.php', 'override content');
 
         $base = $this->makeProviderPackage(
             'yii2-extensions/base',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -379,12 +355,7 @@ final class ScaffolderTest extends TestCase
             'yii2-extensions/override',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -429,18 +400,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/app-base-scaffold', 'stubs/nginx.conf', 'server {}');
+        $builder->createStubFile('yii2-extensions/app-base-scaffold', 'nginx.conf', 'server {}');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/app-base-scaffold',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'nginx.conf' => [
-                            'source' => 'stubs/nginx.conf',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['nginx.conf'],
                 ],
             ],
         );
@@ -484,7 +450,7 @@ final class ScaffolderTest extends TestCase
             ->with(self::stringContains('No extra.scaffold configuration'));
 
         (new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist([]), new PathValidator(), new Hasher(), new NullIO()),
             new LockFile($builder->getProjectRoot()),
             $io,
@@ -495,7 +461,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/good', 'stubs/app.php', 'good-content');
+        $builder->createStubFile('yii2-extensions/good', 'app.php', 'good-content');
 
         $bad = $this->makeProviderPackage(
             'yii2-extensions/bad',
@@ -506,12 +472,7 @@ final class ScaffolderTest extends TestCase
             'yii2-extensions/good',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -520,7 +481,7 @@ final class ScaffolderTest extends TestCase
 
         $bufferIo = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(
                 new PackageAllowlist(['yii2-extensions/bad', 'yii2-extensions/good']),
                 new PathValidator(),
@@ -556,18 +517,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/good', 'stubs/app.php', 'good-content');
+        $builder->createStubFile('yii2-extensions/good', 'app.php', 'good-content');
 
         $good = $this->makeProviderPackage(
             'yii2-extensions/good',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -576,7 +532,7 @@ final class ScaffolderTest extends TestCase
 
         $bufferIo = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(
                 new PackageAllowlist(['yii2-extensions/missing', 'yii2-extensions/good']),
                 new PathValidator(),
@@ -606,22 +562,16 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/a.php', 'a');
-        $builder->createStubFile('yii2-extensions/test', 'stubs/b.php', 'b');
+        $builder->createStubFile('yii2-extensions/test', 'a.php', 'a');
+        $builder->createStubFile('yii2-extensions/test', 'b.php', 'b');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'a.php' => [
-                            'source' => 'stubs/a.php',
-                            'mode' => 'replace',
-                        ],
-                        'b.php' => [
-                            'source' => 'stubs/b.php',
-                            'mode' => 'replace',
-                        ],
+                    'copy' => [
+                        'a.php',
+                        'b.php',
                     ],
                 ],
             ],
@@ -656,18 +606,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/good', 'stubs/app.php', 'good-content');
+        $builder->createStubFile('yii2-extensions/good', 'app.php', 'good-content');
 
         $good = $this->makeProviderPackage(
             'yii2-extensions/good',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -688,7 +633,7 @@ final class ScaffolderTest extends TestCase
 
         $bufferIo = new BufferIO();
         $scaffolder = new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist(['yii2-extensions/good']), new PathValidator(), new Hasher(), $bufferIo),
             new LockFile($builder->getProjectRoot()),
             $bufferIo,
@@ -746,19 +691,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/prepend.txt', 'header');
+        $builder->createStubFile('yii2-extensions/test', 'prepend.txt', 'header');
         $builder->createProjectFile('prepend.txt', 'existing');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'prepend.txt' => [
-                            'source' => 'stubs/prepend.txt',
-                            'mode' => 'prepend',
-                        ],
-                    ],
+                    'copy' => ['prepend.txt'],
+                    'modes' => ['prepend.txt' => 'prepend'],
                 ],
             ],
         );
@@ -785,19 +726,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createStubFile('yii2-extensions/test', 'config.php', 'stub');
         $builder->createProjectFile('config.php', 'user-content');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'config.php' => [
-                            'source' => 'stubs/config.php',
-                            'mode' => 'preserve',
-                        ],
-                    ],
+                    'copy' => ['config.php'],
+                    'modes' => ['config.php' => 'preserve'],
                 ],
             ],
         );
@@ -825,19 +762,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/config/params.php', 'stub content');
+        $builder->createStubFile('yii2-extensions/test', 'config/params.php', 'stub content');
         $builder->createProjectFile('config/params.php', 'user content');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'config/params.php' => [
-                            'source' => 'stubs/config/params.php',
-                            'mode' => 'preserve',
-                        ],
-                    ],
+                    'copy' => ['config/params.php'],
+                    'modes' => ['config/params.php' => 'preserve'],
                 ],
             ],
         );
@@ -872,19 +805,15 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createStubFile('yii2-extensions/test', 'config.php', 'stub');
         $builder->createProjectFile('config.php', 'user-content');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'config.php' => [
-                            'source' => 'stubs/config.php',
-                            'mode' => 'preserve',
-                        ],
-                    ],
+                    'copy' => ['config.php'],
+                    'modes' => ['config.php' => 'preserve'],
                 ],
             ],
         );
@@ -923,18 +852,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/app-base-scaffold', 'stubs/config/params.php', '<?php return [];');
+        $builder->createStubFile('yii2-extensions/app-base-scaffold', 'config/params.php', '<?php return [];');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/app-base-scaffold',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'config/params.php' => [
-                            'source' => 'stubs/config/params.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['config/params.php'],
                 ],
             ],
         );
@@ -957,18 +881,13 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'v1');
+        $builder->createStubFile('yii2-extensions/test', 'app.php', 'v1');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'app.php' => [
-                            'source' => 'stubs/app.php',
-                            'mode' => 'replace',
-                        ],
-                    ],
+                    'copy' => ['app.php'],
                 ],
             ],
         );
@@ -980,7 +899,7 @@ final class ScaffolderTest extends TestCase
         $firstHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
 
         // change the stub so the second run writes different content.
-        $builder->createStubFile('yii2-extensions/test', 'stubs/app.php', 'v2');
+        $builder->createStubFile('yii2-extensions/test', 'app.php', 'v2');
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $secondHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
@@ -1001,7 +920,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/config.php', 'stub');
+        $builder->createStubFile('yii2-extensions/test', 'config.php', 'stub');
         $builder->createProjectFile('config.php', 'user-content');
 
         $userHash = (new Hasher())->hash($builder->getProjectRoot() . '/config.php');
@@ -1019,7 +938,7 @@ final class ScaffolderTest extends TestCase
                     'config.php' => [
                         'hash' => $userHash,
                         'provider' => 'yii2-extensions/test',
-                        'source' => 'stubs/config.php',
+                        'source' => 'config.php',
                         'mode' => 'preserve',
                     ],
                 ],
@@ -1030,12 +949,8 @@ final class ScaffolderTest extends TestCase
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'config.php' => [
-                            'source' => 'stubs/config.php',
-                            'mode' => 'preserve',
-                        ],
-                    ],
+                    'copy' => ['config.php'],
+                    'modes' => ['config.php' => 'preserve'],
                 ],
             ],
         );
@@ -1062,24 +977,19 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        $builder->createStubFile('yii2-extensions/test', 'stubs/append.txt', 'appended');
-        $builder->createStubFile('yii2-extensions/test', 'stubs/fresh.txt', 'fresh content');
+        $builder->createStubFile('yii2-extensions/test', 'append.txt', 'appended');
+        $builder->createStubFile('yii2-extensions/test', 'fresh.txt', 'fresh content');
         $builder->createProjectFile('append.txt', 'existing');
 
         $provider = $this->makeProviderPackage(
             'yii2-extensions/test',
             [
                 'scaffold' => [
-                    'file-mapping' => [
-                        'append.txt' => [
-                            'source' => 'stubs/append.txt',
-                            'mode' => 'append',
-                        ],
-                        'fresh.txt' => [
-                            'source' => 'stubs/fresh.txt',
-                            'mode' => 'replace',
-                        ],
+                    'copy' => [
+                        'append.txt',
+                        'fresh.txt',
                     ],
+                    'modes' => ['append.txt' => 'append'],
                 ],
             ],
         );
@@ -1149,7 +1059,7 @@ final class ScaffolderTest extends TestCase
     private function makeScaffolder(array $allowedPackages, FakeProjectBuilder $builder): Scaffolder
     {
         return new Scaffolder(
-            new ManifestLoader(new ManifestSchema()),
+            new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(
                 new PackageAllowlist($allowedPackages),
                 new PathValidator(),

--- a/tests/support/ComposerEventHarness.php
+++ b/tests/support/ComposerEventHarness.php
@@ -37,8 +37,8 @@ trait ComposerEventHarness
      *
      * @param Composer $composer Live Composer instance whose local repository receives the package.
      * @param string $name Composer package name (for example, `demo/scaffold`).
-     * @param array<string, mixed> $scaffoldManifest Raw `extra.scaffold` array, typically a `{file-mapping: ...}` entry
-     * or an external `{manifest: "scaffold.json"}` pointer.
+     * @param array<string, mixed> $scaffoldManifest Raw `extra.scaffold` array, typically a `{copy: [...]}` inline
+     * manifest or an external `{manifest: "scaffold.json"}` pointer.
      * @param string $version Pretty version string persisted into `scaffold-lock.json`.
      *
      * @return PackageInterface Package that was added to the local repository.
@@ -50,9 +50,9 @@ trait ComposerEventHarness
         string $version = '1.0.0',
     ): PackageInterface {
         $package = new CompletePackage($name, "{$version}.0", $version);
+
         $package->setType('yii2-scaffold');
         $package->setExtra(['scaffold' => $scaffoldManifest]);
-
         $composer->getRepositoryManager()->getLocalRepository()->addPackage($package);
 
         return $package;
@@ -136,7 +136,9 @@ trait ComposerEventHarness
     protected function resetInstallScaffoldRanFlag(): void
     {
         $reflection = new ReflectionClass(EventSubscriber::class);
+
         $property = $reflection->getProperty('installScaffoldRan');
+
         $property->setValue(null, false);
     }
 }

--- a/tests/unit/Manifest/DefaultExcludesTest.php
+++ b/tests/unit/Manifest/DefaultExcludesTest.php
@@ -77,6 +77,45 @@ final class DefaultExcludesTest extends TestCase
         ];
     }
 
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function nonPrunableDirectoryProvider(): array
+    {
+        return [
+            ['src'],
+            ['config'],
+            ['migrations'],
+            ['public'],
+            ['rbac'],
+            ['resources'],
+            ['vendor/bin'],
+            ['.git/hooks'],
+            ['tests/unit'],
+            ['docs/nested'],
+            [''],
+        ];
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function prunableDirectoryProvider(): array
+    {
+        return [
+            ['vendor'],
+            ['.git'],
+            ['.github'],
+            ['tests'],
+            ['.phpunit.cache'],
+            ['phpunit.cache'],
+            ['phpstan.cache'],
+            ['.infection'],
+            ['docs'],
+            ['runtime'],
+        ];
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('excludedPathProvider')]
     public function testExcludedPathMatchesDefaultExcludes(string $path): void
     {
@@ -95,11 +134,31 @@ final class DefaultExcludesTest extends TestCase
         );
     }
 
+    #[\PHPUnit\Framework\Attributes\DataProvider('nonPrunableDirectoryProvider')]
+    public function testNonPrunableDirectoryIsNotMatchedByMatchesDirectory(string $relativeDir): void
+    {
+        self::assertFalse(
+            DefaultExcludes::matchesDirectory($relativeDir),
+            "'{$relativeDir}' must not be pruned: no default pattern of the form '{$relativeDir}/**' excludes every "
+            . 'possible descendant.',
+        );
+    }
+
     public function testPatternsArrayIsNotEmpty(): void
     {
         self::assertNotEmpty(
             DefaultExcludes::PATTERNS,
             'DefaultExcludes::PATTERNS must declare at least one default-exclude pattern.',
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('prunableDirectoryProvider')]
+    public function testPrunableDirectoryIsMatchedByMatchesDirectory(string $relativeDir): void
+    {
+        self::assertTrue(
+            DefaultExcludes::matchesDirectory($relativeDir),
+            "'{$relativeDir}' must be prunable: a default pattern of the form '{$relativeDir}/**' excludes every "
+            . 'possible descendant, so descent can be safely skipped.',
         );
     }
 }

--- a/tests/unit/Manifest/DefaultExcludesTest.php
+++ b/tests/unit/Manifest/DefaultExcludesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Manifest;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use yii\scaffold\Manifest\DefaultExcludes;
+
+/**
+ * Unit tests for {@see DefaultExcludes} built-in exclusion patterns.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('manifest')]
+final class DefaultExcludesTest extends TestCase
+{
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function excludedPathProvider(): array
+    {
+        return [
+            ['composer.json'],
+            ['composer.lock'],
+            ['vendor/autoload.php'],
+            ['vendor/nested/pkg/file.php'],
+            ['.git/HEAD'],
+            ['.github/workflows/ci.yml'],
+            ['.gitattributes'],
+            ['.gitignore'],
+            ['tests/unit/SomeTest.php'],
+            ['tests/functional/deep/Fixture.php'],
+            ['phpunit.xml'],
+            ['phpunit.xml.dist'],
+            ['.phpunit.cache/foo'],
+            ['phpstan.neon'],
+            ['phpstan.neon.dist'],
+            ['phpstan.cache/bar'],
+            ['infection.json5'],
+            ['infection.log'],
+            ['.editorconfig'],
+            ['.php-cs-fixer.php'],
+            ['.php-cs-fixer.dist.php'],
+            ['ecs.php'],
+            ['psalm.xml'],
+            ['README.md'],
+            ['CHANGELOG.md'],
+            ['LICENSE'],
+            ['docs/providers.md'],
+            ['scaffold.json'],
+            ['scaffold-lock.json'],
+            ['runtime/cache/foo'],
+            ['runtime/.gitignore'],
+        ];
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function includedPathProvider(): array
+    {
+        return [
+            ['src/controllers/SiteController.php'],
+            ['src/models/User.php'],
+            ['config/params.php'],
+            ['config/web.php'],
+            ['migrations/M2024_CreateUserTable.php'],
+            ['public/index.php'],
+            ['public/assets/.gitkeep'],
+            ['yii'],
+            ['rbac/items.php'],
+            ['resources/mail/layouts/html.php'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('excludedPathProvider')]
+    public function testExcludedPathMatchesDefaultExcludes(string $path): void
+    {
+        self::assertTrue(
+            DefaultExcludes::matches($path),
+            "'{$path}' must match at least one default-exclude pattern.",
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('includedPathProvider')]
+    public function testIncludedPathDoesNotMatchDefaultExcludes(string $path): void
+    {
+        self::assertFalse(
+            DefaultExcludes::matches($path),
+            "'{$path}' is project content and must not match any default-exclude pattern.",
+        );
+    }
+
+    public function testPatternsArrayIsNotEmpty(): void
+    {
+        self::assertNotEmpty(
+            DefaultExcludes::PATTERNS,
+            'DefaultExcludes::PATTERNS must declare at least one default-exclude pattern.',
+        );
+    }
+}

--- a/tests/unit/Manifest/GlobTest.php
+++ b/tests/unit/Manifest/GlobTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Manifest;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use yii\scaffold\Manifest\Glob;
+
+/**
+ * Unit tests for {@see Glob} pattern-to-regex conversion and matching semantics.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('manifest')]
+final class GlobTest extends TestCase
+{
+    public function testDoubleStarCrossesDirectorySeparators(): void
+    {
+        self::assertTrue(
+            Glob::matches('public/**', 'public/assets/css/app.css'),
+            "'**' must match deep nested paths across '/' separators.",
+        );
+    }
+
+    public function testDoubleStarPrefixMatchesRootFile(): void
+    {
+        self::assertTrue(
+            Glob::matches('**/.gitignore', '.gitignore'),
+            "'**/.gitignore' must match a root-level '.gitignore' because '**' can expand to empty.",
+        );
+    }
+
+    public function testDoubleStarSlashMatchesDeeplyNestedPath(): void
+    {
+        self::assertTrue(
+            Glob::matches('**/foo', 'a/b/c/foo'),
+            "'**/foo' must match arbitrarily deep nested paths.",
+        );
+    }
+
+    public function testExactPathMatchesItself(): void
+    {
+        self::assertTrue(
+            Glob::matches('config/params.php', 'config/params.php'),
+            'Literal patterns must match themselves byte-exact.',
+        );
+    }
+
+    public function testExactPathRejectsDifferentFile(): void
+    {
+        self::assertFalse(
+            Glob::matches('config/params.php', 'config/web.php'),
+            'Literal patterns must not match a different file name.',
+        );
+    }
+
+    public function testQuestionMarkMatchesSingleNonSeparatorChar(): void
+    {
+        self::assertTrue(
+            Glob::matches('yii?', 'yii0'),
+            "'?' must match a single non-separator character.",
+        );
+        self::assertFalse(
+            Glob::matches('yii?', 'yii/0'),
+            "'?' must not match the path separator.",
+        );
+    }
+
+    public function testSingleStarDoesNotCrossDirectorySeparator(): void
+    {
+        self::assertFalse(
+            Glob::matches('config/*.php', 'config/nested/params.php'),
+            "A single '*' must not match across '/' separators.",
+        );
+    }
+
+    public function testSingleStarMatchesSameLevel(): void
+    {
+        self::assertTrue(
+            Glob::matches('config/*.php', 'config/params.php'),
+            "'*.php' must match any file with '.php' extension at the same directory level.",
+        );
+    }
+
+    public function testToRegexAnchorsTheFullPath(): void
+    {
+        self::assertSame(
+            '#^config/[^/]*\.php$#',
+            Glob::toRegex('config/*.php'),
+            "'toRegex' must produce an anchored regex matching the full string.",
+        );
+    }
+
+    public function testToRegexEscapesPunctuation(): void
+    {
+        self::assertSame(
+            '#^file\.with\.dots$#',
+            Glob::toRegex('file.with.dots'),
+            "Literal '.' characters must be escaped in the produced regex.",
+        );
+    }
+
+    public function testToRegexTreatsDoubleStarSlashAsOptionalDirectoryChain(): void
+    {
+        self::assertSame(
+            '#^(?:.*/)?foo$#',
+            Glob::toRegex('**/foo'),
+            "'**/' must compile to '(?:.*/)?' so the match succeeds with zero or more directory levels.",
+        );
+    }
+}

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\unit\Manifest;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use yii\scaffold\Manifest\{FileMapping, FileMode, ManifestExpander};
+use yii\scaffold\tests\support\TempDirectoryTrait;
+
+use function file_put_contents;
+
+/**
+ * Unit tests for {@see ManifestExpander} covering directory walking, exclusions, and mode resolution.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+#[Group('scaffold')]
+#[Group('manifest')]
+final class ManifestExpanderTest extends TestCase
+{
+    use TempDirectoryTrait;
+
+    public function testExpandAppliesDefaultExcludesDuringDirectoryWalk(): void
+    {
+        $this->seedFile('src/controllers/SiteController.php');
+        $this->seedFile('src/tests/SomeTest.php');
+        $this->seedFile('composer.json');
+        $this->seedFile('runtime/cache/x.log');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['.'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertContains(
+            'src/controllers/SiteController.php',
+            $this->destinations($mappings),
+            "Walking '.' must emit the controller file as a destination.",
+        );
+        self::assertNotContains(
+            'composer.json',
+            $this->destinations($mappings),
+            "Default excludes must hide 'composer.json' when '.' is walked.",
+        );
+        self::assertNotContains(
+            'runtime/cache/x.log',
+            $this->destinations($mappings),
+            "Default excludes must hide 'runtime/**' contents when the directory is walked.",
+        );
+    }
+
+    public function testExpandAppliesUserExcludesOnTopOfDefaults(): void
+    {
+        $this->seedFile('src/controllers/SiteController.php');
+        $this->seedFile('src/controllers/Disabled.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src'],
+                'exclude' => ['src/controllers/Disabled.php'],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['src/controllers/SiteController.php'],
+            $this->destinations($mappings),
+            "User-declared 'exclude[]' patterns must filter walked paths.",
+        );
+    }
+
+    public function testExpandAttributesEveryMappingToTheProviderName(): void
+    {
+        $this->seedFile('src/Foo.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+            providerName: 'pkg/example'
+        );
+
+        self::assertNotEmpty(
+            $mappings,
+            'Seed fixture must produce at least one mapping.',
+        );
+
+        foreach ($mappings as $mapping) {
+            self::assertSame(
+                'pkg/example',
+                $mapping->providerName,
+                'Every FileMapping must carry the provider name for lock-file provenance.',
+            );
+        }
+    }
+
+    public function testExpandDedupContinueDoesNotBreakDirectoryWalk(): void
+    {
+        /*
+         * Alphabetic iteration guarantees 'a.php' is processed first by the walk. Pre-adding it as an explicit file
+         * entry in 'copy[]' seeds the dedup map for that key; the walk then hits 'a.php', finds it already seen,
+         * and must 'continue' to iterate 'b.php' / 'c.php'. Replacing 'continue' with 'break' would halt the walk
+         * and strip both follow-up destinations from the output.
+         */
+        $this->seedFile('a.php');
+        $this->seedFile('b.php');
+        $this->seedFile('c.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['a.php', '.'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+        $destinations = $this->destinations($mappings);
+
+        self::assertContains(
+            'b.php',
+            $destinations,
+            "After 'a.php' hits the dedup branch, the walk must 'continue' so 'b.php' still lands in the output.",
+        );
+        self::assertContains(
+            'c.php',
+            $destinations,
+            "After 'a.php' hits the dedup branch, the walk must 'continue' so 'c.php' still lands in the output.",
+        );
+    }
+
+    public function testExpandDeduplicatesWhenFileIsReachableByBothFileAndDirectoryEntries(): void
+    {
+        $this->seedFile('yii');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['yii', '.'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        $destinations = $this->destinations($mappings);
+
+        self::assertSame(
+            1,
+            array_count_values($destinations)['yii'] ?? 0,
+            'A destination reachable from both an explicit file entry and a directory walk must appear only once.',
+        );
+    }
+
+    public function testExpandEmitsEntriesForEachFileInsideCopyDirectory(): void
+    {
+        $this->seedFile('src/controllers/SiteController.php');
+        $this->seedFile('src/models/User.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['src/controllers/SiteController.php', 'src/models/User.php'],
+            $this->destinations($mappings),
+            "Walking 'src' must emit every file beneath it as a destination.",
+        );
+    }
+
+    public function testExpandResolvesExactMatchInModesAndShortCircuitsGlobLoop(): void
+    {
+        // Declaration order matters: the broader glob 'config/*.php' is declared BEFORE the exact path; the default
+        // code path short-circuits via 'isset($modes[$relative])' returning Replace. Removing that early return
+        // would fall through to the foreach and let the first-declared glob win with Preserve, a distinct mode.
+        $this->seedFile('config/params.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['config/params.php'],
+                'exclude' => [],
+                'modes' => [
+                    'config/*.php' => FileMode::Preserve,
+                    'config/params.php' => FileMode::Replace,
+                ],
+            ],
+        );
+
+        self::assertSame(
+            FileMode::Replace,
+            $mappings[0]->mode ?? null,
+            'Exact path match must win over a preceding-but-also-matching glob; removing the early return from the '
+            . "'isset' check flips the result to the glob's mode.",
+        );
+    }
+
+    public function testExpandResolvesModesByExactPathThenByGlobThenDefaultsToReplace(): void
+    {
+        $this->seedFile('config/web.php');
+        $this->seedFile('config/params.php');
+        $this->seedFile('src/controllers/SiteController.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => [
+                    'config',
+                    'src',
+                ],
+                'exclude' => [],
+                'modes' => [
+                    'config/params.php' => FileMode::Preserve,
+                    'config/*.php' => FileMode::Append,
+                ],
+            ],
+        );
+
+        $modesByDestination = [];
+
+        foreach ($mappings as $mapping) {
+            $modesByDestination[$mapping->destination] = $mapping->mode;
+        }
+
+        self::assertSame(
+            FileMode::Preserve,
+            $modesByDestination['config/params.php'] ?? null,
+            'Exact path match must win over a glob pattern that would also match.',
+        );
+        self::assertSame(
+            FileMode::Append,
+            $modesByDestination['config/web.php'] ?? null,
+            "Glob 'config/*.php' must resolve 'config/web.php' after the exact-path lookup misses.",
+        );
+        self::assertSame(
+            FileMode::Replace,
+            $modesByDestination['src/controllers/SiteController.php'] ?? null,
+            "A destination with no match in 'modes{}' must default to 'FileMode::Replace'.",
+        );
+    }
+
+    public function testExpandReturnsWalkResultsInAlphabeticallySortedOrder(): void
+    {
+        // Seed files in reverse-alphabetic creation order so the directory's dirent order likely reverses the
+        // desired sequence; the walk must still produce alphabetic ordering, which only holds when 'sort' runs.
+        $this->seedFile('zzz.php');
+        $this->seedFile('mmm.php');
+        $this->seedFile('aaa.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['.'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        $rawOrder = array_map(static fn(FileMapping $mapping): string => $mapping->destination, $mappings);
+
+        self::assertSame(
+            ['aaa.php', 'mmm.php', 'zzz.php'],
+            $rawOrder,
+            "Walk results must be sorted alphabetically so 'scaffold-lock.json' stays deterministic; removing the "
+            . "'sort()' call would leak filesystem-dependent ordering into the lock and make git diffs noisy.",
+        );
+    }
+
+    public function testExpandThrowsWhenCopyEntryDoesNotExistOnDisk(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        $this->expand(
+            [
+                'copy' => ['missing-dir'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+    }
+
+    public function testExpandTreatsExplicitFileInCopyAsPassthroughBypassingDefaultExcludes(): void
+    {
+        $this->seedFile('runtime/.gitignore');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['runtime/.gitignore'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['runtime/.gitignore'],
+            $this->destinations($mappings),
+            'An explicit file entry under a default-excluded directory must still ship because explicit entries bypass '
+            . 'the default excludes.',
+        );
+    }
+
+    public function testExpandUserExcludeGlobMatchesMultipleFiles(): void
+    {
+        $this->seedFile('src/a.txt');
+        $this->seedFile('src/b.txt');
+        $this->seedFile('src/c.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src'],
+                'exclude' => ['src/*.txt'],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['src/c.php'],
+            $this->destinations($mappings),
+            'User exclude globs must filter by pattern, not just literal path.',
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->setUpTempDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTempDirectory();
+    }
+
+    /**
+     * Extracts the destination paths from a list of file mappings.
+     *
+     * @param list<FileMapping> $mappings
+     *
+     * @return list<string>
+     */
+    private function destinations(array $mappings): array
+    {
+        $destinations = array_map(static fn(FileMapping $mapping): string => $mapping->destination, $mappings);
+
+        sort($destinations);
+
+        return $destinations;
+    }
+
+    /**
+     * Invokes {@see ManifestExpander::expand()} against the test's temp directory.
+     *
+     * @param array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} $manifest
+     *
+     * @return list<FileMapping>
+     */
+    private function expand(array $manifest, string $providerName = 'pkg/test'): array
+    {
+        return (new ManifestExpander())->expand($manifest, $this->tempDir, $providerName);
+    }
+
+    /**
+     * Writes an empty file at `$relative` under the temp directory, creating intermediate directories as needed.
+     */
+    private function seedFile(string $relative): void
+    {
+        $absolute = "{$this->tempDir}/{$relative}";
+
+        $this->ensureTestDirectory(dirname($absolute));
+
+        file_put_contents($absolute, '');
+    }
+}

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -10,6 +10,7 @@ use RuntimeException;
 use yii\scaffold\Manifest\{FileMapping, FileMode, ManifestExpander};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
+use function chmod;
 use function file_put_contents;
 
 /**
@@ -86,7 +87,7 @@ final class ManifestExpanderTest extends TestCase
                 'exclude' => [],
                 'modes' => [],
             ],
-            providerName: 'pkg/example'
+            providerName: 'pkg/example',
         );
 
         self::assertNotEmpty(
@@ -101,6 +102,53 @@ final class ManifestExpanderTest extends TestCase
                 'Every FileMapping must carry the provider name for lock-file provenance.',
             );
         }
+    }
+
+    public function testExpandContinuesToNextCopyEntryAfterDeduplicatingRepeatedFile(): void
+    {
+        // Listing the same file twice seeds the dedup map on iter 1 and routes iter 2 through the 'isset' branch.
+        // A third entry after the duplicate proves the outer loop resumes: replacing 'continue' with 'break' on the
+        // dedup branch would exit the foreach and strip 'other.txt' from the output.
+        $this->seedFile('yii');
+        $this->seedFile('other.txt');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['yii', 'yii', 'other.txt'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertContains(
+            'other.txt',
+            $this->destinations($mappings),
+            "After a duplicate file entry hits the dedup branch, the outer loop must 'continue' so subsequent copy "
+            . "entries still process; replacing the 'continue' with 'break' would drop 'other.txt' from the output.",
+        );
+    }
+
+    public function testExpandContinuesToNextCopyEntryAfterWalkingDirectory(): void
+    {
+        // Two sibling directories in 'copy[]' prove the outer loop resumes after a successful dir walk: replacing the
+        // trailing 'continue' with 'break' would exit the foreach after walking 'dir1' and strip 'dir2/b.txt' out.
+        $this->seedFile('dir1/a.txt');
+        $this->seedFile('dir2/b.txt');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['dir1', 'dir2'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertContains(
+            'dir2/b.txt',
+            $this->destinations($mappings),
+            "After walking the first directory, the outer loop must 'continue' so the next entry is walked too; "
+            . "replacing the 'continue' with 'break' would drop 'dir2/b.txt' from the output.",
+        );
     }
 
     public function testExpandDedupContinueDoesNotBreakDirectoryWalk(): void
@@ -174,6 +222,90 @@ final class ManifestExpanderTest extends TestCase
             ['src/controllers/SiteController.php', 'src/models/User.php'],
             $this->destinations($mappings),
             "Walking 'src' must emit every file beneath it as a destination.",
+        );
+    }
+
+    public function testExpandNormalisesTrailingSeparatorInCopyDirectoryEntry(): void
+    {
+        // A trailing '/' on a dir entry used to make the walk skip one character from each filename and emit destinations
+        // like 'src//ile.php'. The 'rtrim' in both the dir-prefix and the absolute-prefix derivation keep the output
+        // identical whether the provider writes 'src' or 'src/'.
+        $this->seedFile('src/controllers/SiteController.php');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src/'],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['src/controllers/SiteController.php'],
+            $this->destinations($mappings),
+            "A trailing '/' on a 'copy' directory entry must produce the same destinations as the un-slashed form; the "
+            . 'expander rtrims trailing separators before deriving paths so no character is dropped and no double slash '
+            . 'appears.',
+        );
+    }
+
+    public function testExpandPrunesDefaultExcludedDirectoriesWithoutDescendingIntoThem(): void
+    {
+        // 'vendor/**' is a default-excluded pattern. Making 'vendor' unreadable proves the recursive filter rejects
+        // descent BEFORE the iterator attempts it: if descent occurred, opendir() on a 0-mode directory would abort
+        // the walk. The walk completing cleanly is the behavioral proof that 'matchesDirectory' pruned the subtree.
+        $this->seedFile('src/main.php');
+        $this->seedFile('vendor/pkg/bogus.php');
+
+        chmod("{$this->tempDir}/vendor", 0);
+
+        try {
+            $mappings = $this->expand(
+                [
+                    'copy' => ['.'],
+                    'exclude' => [],
+                    'modes' => [],
+                ],
+            );
+        } finally {
+            chmod("{$this->tempDir}/vendor", 0755);
+        }
+
+        self::assertSame(
+            ['src/main.php'],
+            $this->destinations($mappings),
+            "Default-excluded directories must be pruned BEFORE descent; otherwise an unreadable 'vendor/' would "
+            . 'derail the walk instead of being silently skipped.',
+        );
+    }
+
+    public function testExpandPrunesUserExcludedDirectoriesWithoutDescendingIntoThem(): void
+    {
+        // A user exclude of the form 'X/**' behaves symmetrically to default patterns: the filter rejects descent
+        // into 'secrets' so the walk never tries to read its contents. 'secrets' is chmod'd to 0 to fail loudly if
+        // descent ever happens.
+        $this->seedFile('src/main.php');
+        $this->seedFile('secrets/keys.txt');
+
+        chmod("{$this->tempDir}/secrets", 0);
+
+        try {
+            $mappings = $this->expand(
+                [
+                    'copy' => ['.'],
+                    'exclude' => ['secrets/**'],
+                    'modes' => [],
+                ],
+            );
+        } finally {
+            chmod("{$this->tempDir}/secrets", 0755);
+        }
+
+        self::assertSame(
+            ['src/main.php'],
+            $this->destinations($mappings),
+            "User-exclude patterns of form 'X/**' must prune the directory BEFORE descent; otherwise an unreadable "
+            . "'secrets/' subtree would derail the walk instead of being silently skipped.",
         );
     }
 
@@ -269,6 +401,30 @@ final class ManifestExpanderTest extends TestCase
             $rawOrder,
             "Walk results must be sorted alphabetically so 'scaffold-lock.json' stays deterministic; removing the "
             . "'sort()' call would leak filesystem-dependent ordering into the lock and make git diffs noisy.",
+        );
+    }
+
+    public function testExpandSkipsExcludedFilesAndContinuesToRemainingEntries(): void
+    {
+        // An exclude pattern that drops one file while keeping its sibling proves the walk resumes after the skip:
+        // replacing the 'continue' in the exclude branch with 'break' would exit the foreach on the first excluded
+        // entry and strip the surviving sibling from the output.
+        $this->seedFile('src/drop.txt');
+        $this->seedFile('src/keep.txt');
+
+        $mappings = $this->expand(
+            [
+                'copy' => ['src'],
+                'exclude' => ['src/drop.txt'],
+                'modes' => [],
+            ],
+        );
+
+        self::assertSame(
+            ['src/keep.txt'],
+            $this->destinations($mappings),
+            "After an excluded file hits the skip branch, the walk must 'continue' so remaining files still process; "
+            . "replacing the 'continue' with 'break' would drop 'src/keep.txt' from the output.",
         );
     }
 

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -12,6 +12,8 @@ use yii\scaffold\tests\support\TempDirectoryTrait;
 
 use function chmod;
 use function file_put_contents;
+use function function_exists;
+use function posix_geteuid;
 
 /**
  * Unit tests for {@see ManifestExpander} covering directory walking, exclusions, and mode resolution.
@@ -251,9 +253,12 @@ final class ManifestExpanderTest extends TestCase
 
     public function testExpandPrunesDefaultExcludedDirectoriesWithoutDescendingIntoThem(): void
     {
-        // 'vendor/**' is a default-excluded pattern. Making 'vendor' unreadable proves the recursive filter rejects
-        // descent BEFORE the iterator attempts it: if descent occurred, opendir() on a 0-mode directory would abort
-        // the walk. The walk completing cleanly is the behavioral proof that 'matchesDirectory' pruned the subtree.
+        // Behavioral proof of descent pruning on POSIX non-root: 'chmod 0' on 'vendor' makes 'opendir()' throw
+        // 'UnexpectedValueException', so the walk only completes when the recursive filter rejects descent BEFORE
+        // the iterator attempts to read the subtree. Windows ignores POSIX mode bits and root bypasses them, so on
+        // those environments the chmod is a no-op; the assertion still holds there via file-level exclude matching,
+        // but the descent-prevention proof is only meaningful when the platform and user honour mode bits.
+        $this->skipUnlessChmodDeniesDirectoryReads();
         $this->seedFile('src/main.php');
         $this->seedFile('vendor/pkg/bogus.php');
 
@@ -281,9 +286,10 @@ final class ManifestExpanderTest extends TestCase
 
     public function testExpandPrunesUserExcludedDirectoriesWithoutDescendingIntoThem(): void
     {
-        // A user exclude of the form 'X/**' behaves symmetrically to default patterns: the filter rejects descent
-        // into 'secrets' so the walk never tries to read its contents. 'secrets' is chmod'd to 0 to fail loudly if
-        // descent ever happens.
+        // Same behavioral proof as the default-exclude companion: requires a platform and user that honour POSIX
+        // mode bits so 'chmod 0' actually denies reads. On Windows or root the chmod is a no-op and this test
+        // degrades to a file-level exclusion check; the guard below skips it explicitly in those cases.
+        $this->skipUnlessChmodDeniesDirectoryReads();
         $this->seedFile('src/main.php');
         $this->seedFile('secrets/keys.txt');
 
@@ -531,5 +537,23 @@ final class ManifestExpanderTest extends TestCase
         $this->ensureTestDirectory(dirname($absolute));
 
         file_put_contents($absolute, '');
+    }
+
+    /**
+     * Skips the current test when the platform or user cannot make `chmod(dir, 0)` deny directory reads.
+     *
+     * Windows ignores POSIX mode bits entirely, and the root user bypasses them, so a `chmod 0` guard degrades to a
+     * no-op in either environment; the tests that rely on it for descent-prevention proof cannot produce a signal
+     * there and must be skipped rather than silently pass.
+     */
+    private function skipUnlessChmodDeniesDirectoryReads(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('chmod mode bits are not enforced on Windows.');
+        }
+
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            self::markTestSkipped('Running as root bypasses chmod mode bits.');
+        }
     }
 }

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -9,12 +9,14 @@ use JsonException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Xepozz\InternalMocker\MockerState;
-use yii\scaffold\Manifest\{FileMapping, FileMode, ManifestLoader, ManifestSchema};
+use yii\scaffold\Manifest\{FileMode, ManifestExpander, ManifestLoader, ManifestSchema};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
+use function file_put_contents;
+use function json_encode;
+
 /**
- * Unit tests for {@see ManifestLoader} inline and external manifest loading.
+ * Unit tests for {@see ManifestLoader} inline and external manifest loading with the `copy`/`exclude`/`modes` schema.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -25,8 +27,11 @@ final class ManifestLoaderTest extends TestCase
 {
     use TempDirectoryTrait;
 
-    public function testAllFileMappingsAreInstancesOfFileMapping(): void
+    public function testLoadExpandsInlineManifest(): void
     {
+        $this->seedFile('src/Foo.php');
+        $this->seedFile('config/params.php');
+
         $package = self::createStub(PackageInterface::class);
 
         $package
@@ -34,465 +39,248 @@ final class ManifestLoaderTest extends TestCase
             ->willReturn(
                 [
                     'scaffold' => [
-                        'file-mapping' => [
-                            'a.php' => [
-                                'source' => 'stubs/a.php',
-                                'mode' => 'replace',
-                            ],
-                            'b.php' => [
-                                'source' => 'stubs/b.php',
-                                'mode' => 'preserve',
-                            ],
-                        ],
+                        'copy' => ['src', 'config'],
+                        'modes' => ['config/*.php' => 'preserve'],
                     ],
                 ],
             );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getName')->willReturn('pkg/example');
 
-        $result = (new ManifestLoader(new ManifestSchema()))->load($package, '/vendor/yii2-extensions/test');
+        $result = $this->loader()->load($package, $this->tempDir);
+
+        self::assertCount(
+            2,
+            $result,
+            'Inline manifest must produce one FileMapping per expanded file.',
+        );
+
+        $modes = [];
 
         foreach ($result as $mapping) {
-            self::assertInstanceOf(
-                FileMapping::class,
-                $mapping,
-                'Expected all items in result to be instances of FileMapping',
+            $modes[$mapping->destination] = $mapping->mode;
+
+            self::assertSame(
+                'pkg/example',
+                $mapping->providerName,
+                'Every FileMapping must be attributed to the provider name.',
             );
         }
+
+        self::assertSame(
+            FileMode::Preserve,
+            $modes['config/params.php'] ?? null,
+            "'config/*.php' glob must resolve to FileMode::Preserve.",
+        );
+        self::assertSame(
+            FileMode::Replace,
+            $modes['src/Foo.php'] ?? null,
+            'Files with no matching mode must default to FileMode::Replace.',
+        );
     }
 
-    public function testExternalManifestLoadsFileMappings(): void
+    public function testLoadExternalManifestPreservesEveryDeclaredKey(): void
     {
-        $providerPath = dirname(__DIR__, 2) . '/fixtures/providers/valid-external';
+        // Seed two copy roots AND multiple exclude / mode entries so any silent truncation of the decoded manifest
+        // (for example, keeping only the first array element) would drop assertions that depend on the full structure.
+        $this->seedFile('src/Foo.php');
+        $this->seedFile('config/params.php');
+        $this->seedFile('config/web.php');
+
+        $manifest = [
+            'copy' => ['src', 'config'],
+            'exclude' => ['config/secrets.php'],
+            'modes' => ['config/*.php' => 'preserve'],
+        ];
+
+        file_put_contents("{$this->tempDir}/scaffold.json", (string) json_encode($manifest));
 
         $package = self::createStub(PackageInterface::class);
 
         $package
             ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'scaffold.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/inertia-vue-scaffold');
+            ->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
+        $package->method('getName')->willReturn('pkg/example');
 
-        $result = (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
+        $result = $this->loader()->load($package, $this->tempDir);
 
-        self::assertCount(
-            2,
-            $result,
-            "Expected exactly '2' FileMappings in result.",
-        );
+        $destinations = [];
 
-        $first = array_shift($result);
-
-        if ($first === null) {
-            self::fail('Expected at least one FileMapping in result.');
+        foreach ($result as $mapping) {
+            $destinations[$mapping->destination] = $mapping->mode;
         }
 
-        self::assertSame(
-            'resources/js/app.js',
-            $first->destination,
-            "Expected destination to be 'resources/js/app.js'",
+        self::assertArrayHasKey(
+            'src/Foo.php',
+            $destinations,
+            "The 'src' copy root must survive decoding; losing the second copy entry would hide this destination.",
         );
-        self::assertSame(
-            'stubs/resources/js/app.js',
-            $first->source,
-            "Expected source to be 'stubs/resources/js/app.js'",
+        self::assertArrayHasKey(
+            'config/params.php',
+            $destinations,
+            "The 'config' copy root must survive decoding; it is declared as the second entry of 'copy[]'.",
         );
         self::assertSame(
             FileMode::Preserve,
-            $first->mode,
-            "Expected mode to be 'FileMode::Preserve'.",
-        );
-        self::assertSame(
-            'yii2-extensions/inertia-vue-scaffold',
-            $first->providerName,
-            "Expected providerName to be 'yii2-extensions/inertia-vue-scaffold'",
-        );
-        self::assertSame(
-            $providerPath,
-            $first->providerPath,
-            "Expected providerPath to be '{$providerPath}'",
+            $destinations['config/params.php'] ?? null,
+            "The 'modes{}' key must survive decoding so the glob applies the expected mode.",
         );
     }
 
-    public function testExternalManifestWhenFileGetContentsFailsThrows(): void
+    public function testLoadReadsExternalManifestRelativeToProviderRoot(): void
     {
-        $manifestPath = "{$this->tempDir}/scaffold.json";
+        $this->seedFile('src/Foo.php');
 
-        file_put_contents($manifestPath, '{}');
+        $manifest = ['copy' => ['src']];
 
-        /**
-         * `default: true` forces the mocker to return `false` for every `file_get_contents` in the Manifest namespace,
-         * independent of how the host platform normalizes the path (Windows backslashes vs. POSIX forward slashes).
-         */
-        MockerState::addCondition(
-            'yii\\scaffold\\Manifest',
-            'file_get_contents',
-            [],
-            false,
-            default: true,
+        file_put_contents("{$this->tempDir}/scaffold.json", (string) json_encode($manifest));
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package
+            ->method('getExtra')
+            ->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
+        $package->method('getName')->willReturn('pkg/example');
+
+        $result = $this->loader()->load($package, $this->tempDir);
+
+        self::assertCount(
+            1,
+            $result,
+            'External manifest must produce mappings identical to an equivalent inline declaration.',
         );
+    }
+
+    public function testLoadReturnsEmptyWhenExtraDoesNotDeclareScaffold(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn([]);
+
+        self::assertSame(
+            [],
+            $this->loader()->load($package, $this->tempDir),
+            'Absence of the "scaffold" key must produce no mappings.',
+        );
+    }
+
+    public function testLoadReturnsEmptyWhenScaffoldIsNotArray(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => 'invalid']);
+
+        self::assertSame(
+            [],
+            $this->loader()->load($package, $this->tempDir),
+            'Non-array "scaffold" value must produce no mappings.',
+        );
+    }
+
+    public function testLoadThrowsWhenExternalManifestDecodesToNonObject(): void
+    {
+        file_put_contents("{$this->tempDir}/scaffold.json", '"just-a-string"');
 
         $package = self::createStub(PackageInterface::class);
 
         $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
-        $package->method('getName')->willReturn('yii2-extensions/bad');
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('could not read manifest file');
+        $this->expectExceptionMessage('decode to an object');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, $this->tempDir);
+        $this->loader()->load($package, $this->tempDir);
     }
 
-    public function testExternalManifestWithBackslashAbsolutePathThrows(): void
+    public function testLoadThrowsWhenExternalManifestFileIsMissing(): void
     {
         $package = self::createStub(PackageInterface::class);
 
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => '\\absolute\\path.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'missing.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('must be a relative path inside the provider root');
+        $this->expectExceptionMessage('manifest file not found');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/some/path');
+        $this->loader()->load($package, $this->tempDir);
     }
 
-    public function testExternalManifestWithDriveLetterAbsolutePathThrows(): void
+    public function testLoadThrowsWhenExternalManifestJsonIsInvalid(): void
+    {
+        file_put_contents("{$this->tempDir}/scaffold.json", '{ not valid json ');
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
+
+        $this->expectException(JsonException::class);
+
+        $this->loader()->load($package, $this->tempDir);
+    }
+
+    public function testLoadThrowsWhenExternalManifestPathContainsTraversal(): void
     {
         $package = self::createStub(PackageInterface::class);
 
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'C:/absolute/path.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => '../escape.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('must be a relative path inside the provider root');
+        $this->expectExceptionMessage('relative path');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/some/path');
+        $this->loader()->load($package, $this->tempDir);
     }
 
-    public function testExternalManifestWithEmptyPathThrows(): void
+    public function testLoadThrowsWhenExternalManifestPathIsAbsolute(): void
     {
         $package = self::createStub(PackageInterface::class);
 
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => ''],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => '/etc/malicious.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        $this->loader()->load($package, $this->tempDir);
+    }
+
+    public function testLoadThrowsWhenExternalManifestPathIsEmptyString(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => '']]);
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('non-empty string');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/some/path');
+        $this->loader()->load($package, $this->tempDir);
     }
 
-    public function testExternalManifestWithMalformedJsonThrows(): void
-    {
-        $providerPath = dirname(__DIR__, 2) . '/fixtures/providers/malformed-manifest';
-
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'scaffold.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/bad');
-
-        $this->expectException(JsonException::class);
-
-        (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
-    }
-
-    public function testExternalManifestWithMidPathColonIsNotTreatedAsAbsolute(): void
+    public function testLoadThrowsWhenExternalManifestPathIsNotString(): void
     {
         $package = self::createStub(PackageInterface::class);
 
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'nested/C:file.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 42]]);
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
-        // Must fall through to the "not found" branch rather than being caught by the absolute-path regex.
-        $this->expectExceptionMessage('manifest file not found');
+        $this->expectExceptionMessage('non-empty string');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/nonexistent/provider');
+        $this->loader()->load($package, $this->tempDir);
     }
 
-    public function testExternalManifestWithMissingFileThrows(): void
+    public function testLoadThrowsWhenInlineManifestOmitsCopy(): void
     {
         $package = self::createStub(PackageInterface::class);
 
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'nonexistent.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/test');
+        $package->method('getExtra')->willReturn(['scaffold' => ['modes' => ['*.php' => 'replace']]]);
+        $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('not found');
+        $this->expectExceptionMessage('"copy"');
 
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/nonexistent/path');
-    }
-
-    public function testExternalManifestWithNonObjectJsonThrows(): void
-    {
-        // write a JSON payload that decodes to a scalar, not an object.
-        file_put_contents("{$this->tempDir}/scaffold.json", '"just a string"');
-
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => 'scaffold.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/bad');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('must decode to an object');
-
-        (new ManifestLoader(new ManifestSchema()))->load($package, $this->tempDir);
-    }
-
-    public function testExternalManifestWithTraversalPathThrows(): void
-    {
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => ['manifest' => '../escape.json'],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/bad');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('must be a relative path inside the provider root');
-
-        (new ManifestLoader(new ManifestSchema()))->load($package, '/vendor/yii2-extensions/bad');
-    }
-
-    public function testInlineFileMappingCarriesProviderNameAndPath(): void
-    {
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => [
-                        'file-mapping' => [
-                            'nginx.conf' => [
-                                'source' => 'stubs/nginx.conf',
-                                'mode' => 'replace',
-                            ],
-                        ],
-                    ],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/nginx-scaffold');
-
-        $result = (new ManifestLoader(new ManifestSchema()))->load(
-            $package,
-            '/vendor/yii2-extensions/nginx-scaffold',
-        );
-
-        self::assertCount(1, $result);
-
-        $mapping = array_shift($result);
-
-        if ($mapping === null) {
-            self::fail('Expected one FileMapping in result.');
-        }
-
-        self::assertSame(
-            'yii2-extensions/nginx-scaffold',
-            $mapping->providerName,
-            "Expected providerName to be 'yii2-extensions/nginx-scaffold'",
-        );
-        self::assertSame(
-            '/vendor/yii2-extensions/nginx-scaffold',
-            $mapping->providerPath,
-            "Expected providerPath to be '/vendor/yii2-extensions/nginx-scaffold'",
-        );
-    }
-
-    public function testInlineMappingLoadsFileMappings(): void
-    {
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(
-                [
-                    'scaffold' => [
-                        'file-mapping' => [
-                            'config/params.php' => [
-                                'source' => 'stubs/params.php',
-                                'mode' => 'preserve',
-                            ],
-                            'vite.config.js' => [
-                                'source' => 'stubs/vite.config.js',
-                                'mode' => 'replace',
-                            ],
-                        ],
-                    ],
-                ],
-            );
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/inertia-vue-scaffold');
-
-        $result = (new ManifestLoader(new ManifestSchema()))->load(
-            $package,
-            '/vendor/yii2-extensions/inertia-vue-scaffold',
-        );
-
-        self::assertCount(
-            2,
-            $result,
-            "Expected exactly '2' FileMappings in result.",
-        );
-
-        $first = array_shift($result);
-
-        if ($first === null) {
-            self::fail('Expected at least one FileMapping in result.');
-        }
-
-        self::assertSame(
-            'config/params.php',
-            $first->destination,
-            "Expected destination to be 'config/params.php'",
-        );
-        self::assertSame(
-            'stubs/params.php',
-            $first->source,
-            "Expected source to be 'stubs/params.php'",
-        );
-        self::assertSame(
-            FileMode::Preserve,
-            $first->mode,
-            "Expected mode to be 'FileMode::Preserve'.",
-        );
-        self::assertSame(
-            'yii2-extensions/inertia-vue-scaffold',
-            $first->providerName,
-            "Expected providerName to be 'yii2-extensions/inertia-vue-scaffold'",
-        );
-        self::assertSame(
-            '/vendor/yii2-extensions/inertia-vue-scaffold',
-            $first->providerPath,
-            "Expected providerPath to be '/vendor/yii2-extensions/inertia-vue-scaffold'",
-        );
-    }
-
-    public function testPackageWithNoScaffoldExtraReturnsEmptyArray(): void
-    {
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn([]);
-        $package
-            ->method('getName')
-            ->willReturn('some/package');
-
-        self::assertSame(
-            [],
-            (new ManifestLoader(new ManifestSchema()))->load($package, '/vendor/some/package'),
-            'Expected empty array when no scaffold extra is present',
-        );
-    }
-
-    public function testPackageWithScaffoldExtraButNoMappingReturnsEmptyArray(): void
-    {
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn(['scaffold' => ['locations' => ['web-root' => 'public/']]]);
-        $package
-            ->method('getName')
-            ->willReturn('some/package');
-
-        self::assertSame(
-            [],
-            (new ManifestLoader(new ManifestSchema()))->load($package, '/vendor/some/package'),
-            'Expected empty array when scaffold extra is present but no mapping is defined',
-        );
-    }
-
-    public function testSchemaViolationInExternalManifestThrows(): void
-    {
-        $providerPath = dirname(__DIR__, 2) . '/fixtures/providers/invalid-traversal';
-
-        $package = self::createStub(PackageInterface::class);
-
-        $package
-            ->method('getExtra')
-            ->willReturn([
-                'scaffold' => ['manifest' => 'scaffold.json'],
-            ]);
-        $package
-            ->method('getName')
-            ->willReturn('yii2-extensions/bad');
-
-        $this->expectException(RuntimeException::class);
-
-        (new ManifestLoader(new ManifestSchema()))->load($package, $providerPath);
+        $this->loader()->load($package, $this->tempDir);
     }
 
     protected function setUp(): void
@@ -503,5 +291,25 @@ final class ManifestLoaderTest extends TestCase
     protected function tearDown(): void
     {
         $this->tearDownTempDirectory();
+    }
+
+    /**
+     * Builds a {@see ManifestLoader} with real dependencies.
+     */
+    private function loader(): ManifestLoader
+    {
+        return new ManifestLoader(new ManifestSchema(), new ManifestExpander());
+    }
+
+    /**
+     * Writes an empty file at `$relative` under the temp directory, creating intermediate directories as needed.
+     */
+    private function seedFile(string $relative): void
+    {
+        $absolute = "{$this->tempDir}/{$relative}";
+
+        $this->ensureTestDirectory(dirname($absolute));
+
+        file_put_contents($absolute, '');
     }
 }

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -28,6 +28,33 @@ final class ManifestLoaderTest extends TestCase
 {
     use TempDirectoryTrait;
 
+    public function testLoadAcceptsExternalManifestPathContainingColonInNonLeadingPosition(): void
+    {
+        // Guards the '^' anchor in the drive-letter regex '/^[A-Za-z]:/' inside 'readExternal': without the anchor,
+        // ordinary relative paths that contain a letter-colon anywhere (stream wrappers, namespace separators, etc.)
+        // would be wrongly rejected as absolute Windows paths.
+        $manifest = ['copy' => ['src']];
+
+        $this->seedFile('src/Foo.php');
+        $this->ensureTestDirectory("{$this->tempDir}/subdir");
+
+        file_put_contents("{$this->tempDir}/subdir/a:b.json", (string) json_encode($manifest));
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'subdir/a:b.json']]);
+        $package->method('getName')->willReturn('pkg/example');
+
+        $result = $this->loader()->load($package, $this->tempDir);
+
+        self::assertCount(
+            1,
+            $result,
+            "A manifest path whose non-leading segment contains '[A-Za-z]:' must load normally; the drive-letter "
+            . "check must only fire when the WHOLE path starts with '[A-Za-z]:'.",
+        );
+    }
+
     public function testLoadExpandsInlineManifest(): void
     {
         $this->seedFile('src/Foo.php');

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -9,6 +9,7 @@ use JsonException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Xepozz\InternalMocker\MockerState;
 use yii\scaffold\Manifest\{FileMode, ManifestExpander, ManifestLoader, ManifestSchema};
 use yii\scaffold\tests\support\TempDirectoryTrait;
 
@@ -176,6 +177,34 @@ final class ManifestLoaderTest extends TestCase
         );
     }
 
+    public function testLoadThrowsWhenExternalManifestCannotBeRead(): void
+    {
+        // Forcing 'file_get_contents' to 'false' isolates the narrow error path where 'is_file()' succeeds but reading
+        // the file fails (for example, a race in which the file is unlinked between the existence check and the read,
+        // or a filesystem quota hit mid-read). The mocker intercepts the call in the 'yii\\scaffold\\Manifest'
+        // namespace so the production code returns the expected I/O failure without touching real filesystem state.
+        $manifestPath = "{$this->tempDir}/scaffold.json";
+
+        file_put_contents($manifestPath, '{}');
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Manifest',
+            'file_get_contents',
+            [$manifestPath, false, null, 0, null],
+            false,
+        );
+
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'scaffold.json']]);
+        $package->method('getName')->willReturn('pkg/unreadable');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('could not read manifest file');
+
+        $this->loader()->load($package, $this->tempDir);
+    }
+
     public function testLoadThrowsWhenExternalManifestDecodesToNonObject(): void
     {
         file_put_contents("{$this->tempDir}/scaffold.json", '"just-a-string"');
@@ -236,6 +265,32 @@ final class ManifestLoaderTest extends TestCase
         $package = self::createStub(PackageInterface::class);
 
         $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => '/etc/malicious.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        $this->loader()->load($package, $this->tempDir);
+    }
+
+    public function testLoadThrowsWhenExternalManifestPathIsAbsoluteWindowsBackslash(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => '\\Windows\\scaffold.json']]);
+        $package->method('getName')->willReturn('pkg/bad');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        $this->loader()->load($package, $this->tempDir);
+    }
+
+    public function testLoadThrowsWhenExternalManifestPathIsAbsoluteWindowsDrive(): void
+    {
+        $package = self::createStub(PackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['manifest' => 'C:\\malicious.json']]);
         $package->method('getName')->willReturn('pkg/bad');
 
         $this->expectException(RuntimeException::class);

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -77,6 +77,7 @@ final class ManifestSchemaTest extends TestCase
             'All four FileMode cases must resolve correctly from their string values.',
         );
     }
+
     public function testValidateReturnsTypedStructureForMinimalManifest(): void
     {
         $result = (new ManifestSchema())->validate(['copy' => ['src']]);
@@ -102,6 +103,14 @@ final class ManifestSchemaTest extends TestCase
         $this->expectExceptionMessage('relative path');
 
         (new ManifestSchema())->validate(['copy' => ['/etc']]);
+    }
+
+    public function testValidateThrowsWhenCopyEntryIsAbsoluteWindowsBackslashPath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        (new ManifestSchema())->validate(['copy' => ['\\Windows\\System32']]);
     }
 
     public function testValidateThrowsWhenCopyEntryIsAbsoluteWindowsPath(): void

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -19,6 +19,21 @@ use yii\scaffold\Manifest\{FileMode, ManifestSchema};
 #[Group('manifest')]
 final class ManifestSchemaTest extends TestCase
 {
+    public function testValidateAcceptsCopyEntryContainingColonInNonLeadingPosition(): void
+    {
+        // The '^' anchor in the drive-letter regex '/^[A-Za-z]:/' is load-bearing: without it, any letter followed by
+        // a colon anywhere in the string would trigger the absolute-path rejection, blocking legitimate relative
+        // paths that happen to include ':' (namespace separators, resource fork addresses, stream wrappers, etc.).
+        $result = (new ManifestSchema())->validate(['copy' => ['some/module:file.php']]);
+
+        self::assertSame(
+            ['some/module:file.php'],
+            $result['copy'],
+            'A colon that is not the second character of the path must be treated as a literal filename byte; the '
+            . "drive-letter check must only fire when the path STARTS with '[A-Za-z]:'.",
+        );
+    }
+
     public function testValidateAcceptsFullManifest(): void
     {
         $result = (new ManifestSchema())->validate(

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -168,6 +168,30 @@ final class ManifestSchemaTest extends TestCase
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => 'invalid']);
     }
 
+    public function testValidateThrowsWhenModesKeyContainsTraversal(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('traversal');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['../escape' => 'preserve']]);
+    }
+
+    public function testValidateThrowsWhenModesKeyIsAbsoluteUnixPath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['/etc/passwd' => 'preserve']]);
+    }
+
+    public function testValidateThrowsWhenModesKeyIsAbsoluteWindowsPath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['C:\\Windows' => 'preserve']]);
+    }
+
     public function testValidateThrowsWhenModesKeyIsEmptyString(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -10,7 +10,7 @@ use RuntimeException;
 use yii\scaffold\Manifest\{FileMode, ManifestSchema};
 
 /**
- * Unit tests for {@see ManifestSchema} manifest structure validation.
+ * Unit tests for {@see ManifestSchema} validation of the `copy` / `exclude` / `modes` shape.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -19,251 +19,176 @@ use yii\scaffold\Manifest\{FileMode, ManifestSchema};
 #[Group('manifest')]
 final class ManifestSchemaTest extends TestCase
 {
-    public function testAllFourModesInOneMappingPass(): void
+    public function testValidateAcceptsFullManifest(): void
     {
-        $this->expectNotToPerformAssertions();
-
-        (new ManifestSchema())->validate(
+        $result = (new ManifestSchema())->validate(
             [
-                'file-mapping' => [
-                    'a.php' => [
-                        'source' => 'stubs/a.php',
-                        'mode' => 'replace',
-                    ],
-                    'b.php' => [
-                        'source' => 'stubs/b.php',
-                        'mode' => 'preserve',
-                    ],
-                    'c.txt' => [
-                        'source' => 'stubs/c.txt',
-                        'mode' => 'append',
-                    ],
-                    'd.txt' => [
-                        'source' => 'stubs/d.txt',
-                        'mode' => 'prepend',
-                    ],
-                ],
+                'copy' => ['src', 'config'],
+                'exclude' => ['config/test-local.php'],
+                'modes' => ['config/*.php' => 'preserve'],
             ],
         );
+
+        self::assertSame(['src', 'config'], $result['copy']);
+        self::assertSame(['config/test-local.php'], $result['exclude']);
+        self::assertSame([FileMode::Preserve], array_values($result['modes']));
+        self::assertSame(['config/*.php'], array_keys($result['modes']));
     }
 
-    public function testDestinationKeyWithIntegerThrows(): void
+    public function testValidatePreservesAllExcludeEntries(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('file-mapping key must be a non-empty string');
-
-        (new ManifestSchema())->validate(
+        $result = (new ManifestSchema())->validate(
             [
-                // an integer key bypasses PHP's string-key conversion and triggers the is_string check.
-                'file-mapping' => [
-                    [
-                        'source' => 'stubs/x.php',
-                        'mode' => 'replace',
-                    ],
-                ],
+                'copy' => ['src'],
+                'exclude' => ['first.php', 'second.php', 'third.php'],
             ],
         );
-    }
-
-    public function testEmptyFileMappingReturnsEmptyArray(): void
-    {
-        $result = (new ManifestSchema())->validate(['file-mapping' => []]);
 
         self::assertSame(
-            [],
-            $result,
-            "Expected empty array for 'file-mapping' when no entries are provided.",
+            ['first.php', 'second.php', 'third.php'],
+            $result['exclude'],
+            "Every 'exclude[]' entry must round-trip through the validator; dropping entries would hide patterns that "
+            . 'the expander must apply.',
         );
     }
 
-    public function testEntryEmptySourceThrows(): void
+    public function testValidateResolvesAllFourModesCorrectly(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"source"');
-
-        (new ManifestSchema())->validate(
+        $result = (new ManifestSchema())->validate(
             [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => '',
-                        'mode' => 'preserve',
-                    ],
+                'copy' => ['src'],
+                'modes' => [
+                    'replace.php' => 'replace',
+                    'preserve.php' => 'preserve',
+                    'append.txt' => 'append',
+                    'prepend.txt' => 'prepend',
                 ],
             ],
         );
+
+        self::assertSame(
+            [
+                'replace.php' => FileMode::Replace,
+                'preserve.php' => FileMode::Preserve,
+                'append.txt' => FileMode::Append,
+                'prepend.txt' => FileMode::Prepend,
+            ],
+            $result['modes'],
+            'All four FileMode cases must resolve correctly from their string values.',
+        );
+    }
+    public function testValidateReturnsTypedStructureForMinimalManifest(): void
+    {
+        $result = (new ManifestSchema())->validate(['copy' => ['src']]);
+
+        self::assertSame(
+            ['copy' => ['src'], 'exclude' => [], 'modes' => []],
+            $result,
+            "Minimal manifest with only 'copy' must default 'exclude' to empty list and 'modes' to empty map.",
+        );
     }
 
-    public function testEntryInvalidModeThrows(): void
+    public function testValidateThrowsWhenCopyEntryContainsTraversal(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('traversal');
+
+        (new ManifestSchema())->validate(['copy' => ['../escape']]);
+    }
+
+    public function testValidateThrowsWhenCopyEntryIsAbsoluteUnixPath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        (new ManifestSchema())->validate(['copy' => ['/etc']]);
+    }
+
+    public function testValidateThrowsWhenCopyEntryIsAbsoluteWindowsPath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('relative path');
+
+        (new ManifestSchema())->validate(['copy' => ['C:\\Windows']]);
+    }
+
+    public function testValidateThrowsWhenCopyEntryIsEmptyString(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('non-empty');
+
+        (new ManifestSchema())->validate(['copy' => ['']]);
+    }
+
+    public function testValidateThrowsWhenCopyIsEmptyArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('at least one path');
+
+        (new ManifestSchema())->validate(['copy' => []]);
+    }
+
+    public function testValidateThrowsWhenCopyIsNotArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"copy"');
+
+        (new ManifestSchema())->validate(['copy' => 'src']);
+    }
+
+    public function testValidateThrowsWhenCopyKeyIsMissing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"copy"');
+
+        (new ManifestSchema())->validate([]);
+    }
+
+    public function testValidateThrowsWhenExcludeEntryContainsTraversal(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('traversal');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'exclude' => ['../bad']]);
+    }
+
+    public function testValidateThrowsWhenExcludeIsNotArray(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"exclude"');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'exclude' => 'not-an-array']);
+    }
+
+    public function testValidateThrowsWhenModesIsNotObject(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('"modes"');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => 'invalid']);
+    }
+
+    public function testValidateThrowsWhenModesKeyIsEmptyString(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('non-empty');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['' => 'preserve']]);
+    }
+
+    public function testValidateThrowsWhenModesValueIsNotString(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a string');
+
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['config/*.php' => 123]]);
+    }
+
+    public function testValidateThrowsWhenModesValueIsUnknownMode(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"unknown-mode"');
 
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => 'stubs/params.php',
-                        'mode' => 'unknown-mode',
-                    ],
-                ],
-            ],
-        );
-    }
-
-    public function testEntryIsNotArrayThrows(): void
-    {
-        $this->expectException(RuntimeException::class);
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/params.php' => 'not-an-object',
-                ],
-            ],
-        );
-    }
-
-    public function testEntryMissingModeKeyThrows(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"mode"');
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/params.php' => ['source' => 'stubs/params.php'],
-                ],
-            ],
-        );
-    }
-
-    public function testEntryMissingSourceKeyThrows(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"source"');
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/params.php' => ['mode' => 'preserve'],
-                ],
-            ],
-        );
-    }
-
-    public function testFileMappingIsNotArrayThrows(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"file-mapping"');
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => 'not-an-array',
-            ],
-        );
-    }
-
-    public function testMissingFileMappingKeyThrows(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"file-mapping"');
-
-        (new ManifestSchema())->validate(
-            [],
-        );
-    }
-
-    public function testValidateReturnsTypedFileMappingArray(): void
-    {
-        $result = (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'nginx.conf' => [
-                        'source' => 'stubs/nginx.conf',
-                        'mode' => 'replace',
-                    ],
-                ],
-            ],
-        );
-
-        $entry = $result['nginx.conf'] ?? null;
-
-        if ($entry === null) {
-            self::fail('Expected "nginx.conf" key in validated result.');
-        }
-
-        self::assertSame(
-            'stubs/nginx.conf',
-            $entry['source'],
-            "Expected 'source' to be 'stubs/nginx.conf' for 'nginx.conf' entry.",
-        );
-        self::assertSame(
-            FileMode::Replace,
-            $entry['mode'],
-            "Expected 'mode' to be 'FileMode::Replace' for 'nginx.conf' entry.",
-        );
-    }
-
-    public function testValidMappingWithAppendModePasses(): void
-    {
-        $this->expectNotToPerformAssertions();
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    '.gitignore' => [
-                        'source' => 'stubs/.gitignore',
-                        'mode' => 'append',
-                    ],
-                ],
-            ],
-        );
-    }
-
-    public function testValidMappingWithPrependModePasses(): void
-    {
-        $this->expectNotToPerformAssertions();
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    '.env.dist' => [
-                        'source' => 'stubs/.env.dist',
-                        'mode' => 'prepend',
-                    ],
-                ],
-            ],
-        );
-    }
-
-    public function testValidMappingWithPreserveModePasses(): void
-    {
-        $this->expectNotToPerformAssertions();
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/params.php' => [
-                        'source' => 'stubs/params.php',
-                        'mode' => 'preserve',
-                    ],
-                ],
-            ],
-        );
-    }
-    public function testValidMappingWithReplaceModePasses(): void
-    {
-        $this->expectNotToPerformAssertions();
-
-        (new ManifestSchema())->validate(
-            [
-                'file-mapping' => [
-                    'config/web.php' => [
-                        'source' => 'stubs/web.php',
-                        'mode' => 'replace',
-                    ],
-                ],
-            ],
-        );
+        (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['config/*.php' => 'unknown-mode']]);
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                               |
| Breaks BC?   |  ✔️                                                             |
