### PR TITLE
test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - feat: port console commands to Symfony Console and ship `vendor/bin/scaffold` as a standalone CLI usable from Yii2, Yii3, Laravel, Symfony, or plain PHP projects.
 - test: kill remaining path-normalization mutants and keep Infection MSI at `100%`.
 - feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.
+- test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.

--- a/tests/functional/ComposerInstallTest.php
+++ b/tests/functional/ComposerInstallTest.php
@@ -146,10 +146,7 @@ final class ComposerInstallTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        /**
-         * `composer.json` has no `extra.scaffold` key at all. runScaffold must continue without errors, emit the
-         * no-config notice inside Scaffolder, and leave the project untouched.
-         */
+        // No 'extra.scaffold' key: runScaffold must emit the no-config notice and leave the project untouched.
         $builder->createComposerJson(
             [
                 'name' => 'demo/smoke-project',
@@ -167,8 +164,7 @@ final class ComposerInstallTest extends TestCase
         self::assertStringContainsString(
             'No extra.scaffold configuration found',
             $io->getOutput(),
-            'Projects without `extra.scaffold` must still dispatch the handler; it must gracefully emit the no-config '
-            . 'notice instead of raising an error.',
+            'Projects without `extra.scaffold` must still dispatch the handler and gracefully emit the no-config notice.',
         );
     }
 
@@ -286,11 +282,7 @@ final class ComposerInstallTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        /**
-         * `pre-populate` scaffold-lock.json with malformed JSON so LockFile::read() throws inside
-         * `Scaffolder::scaffold()`. The EventSubscriber must catch the Throwable and log
-         * `[scaffold] Scaffolding aborted: ...`.
-         */
+        // Malformed lock JSON makes 'LockFile::read()' throw; the EventSubscriber must catch and log the abort.
         file_put_contents("{$builder->getProjectRoot()}/scaffold-lock.json", '{ not valid json');
 
         $builder->createStubFile(

--- a/tests/functional/CreateProjectTest.php
+++ b/tests/functional/CreateProjectTest.php
@@ -83,9 +83,7 @@ final class CreateProjectTest extends TestCase
         self::assertSame(
             "existing\n/runtime/\n",
             file_get_contents($builder->getProjectRoot() . '/.gitignore'),
-            "'onPostCreateProject' must dispatch with 'fullScaffold=true' so append entries are applied even when the "
-            . "destination is already recorded in the lock; flipping the flag to 'false' would short-circuit the append "
-            . "through the 'isset(\$lockData['files'][\$destination])' guard and leave the file untouched.",
+            "'onPostCreateProject' must dispatch with 'fullScaffold=true' so append entries apply even when already locked.",
         );
     }
 
@@ -126,8 +124,7 @@ final class CreateProjectTest extends TestCase
         self::assertSame(
             "/runtime/\n",
             file_get_contents($builder->getProjectRoot() . '/.gitignore'),
-            "'post-create-project-cmd' alone must apply append-mode entries when post-install-cmd did not run "
-            . 'before it.',
+            "'post-create-project-cmd' alone must apply append-mode entries when post-install-cmd did not run before it.",
         );
     }
 
@@ -172,8 +169,7 @@ final class CreateProjectTest extends TestCase
         self::assertSame(
             "/runtime/\n",
             file_get_contents($builder->getProjectRoot() . '/.gitignore'),
-            "'post-create-project-cmd' must short-circuit when 'post-install-cmd' already ran so append-mode lines are "
-            . 'not concatenated twice within the same Composer invocation.',
+            "'post-create-project-cmd' must short-circuit when 'post-install-cmd' already ran to avoid duplicate appends.",
         );
     }
 
@@ -289,9 +285,7 @@ final class CreateProjectTest extends TestCase
         self::assertSame(
             "existing\n",
             file_get_contents($builder->getProjectRoot() . '/.gitignore'),
-            "'onPostInstall' must dispatch with 'fullScaffold=false' so append entries already tracked in the lock are "
-            . "skipped; flipping the flag to 'true' would re-apply the stub and duplicate content across composer "
-            . 'install invocations.',
+            "'onPostInstall' must dispatch with 'fullScaffold=false' so locked append entries are skipped.",
         );
     }
 
@@ -350,9 +344,7 @@ final class CreateProjectTest extends TestCase
         self::assertSame(
             "existing\n",
             file_get_contents($builder->getProjectRoot() . '/.gitignore'),
-            "'onPostUpdate' must dispatch with 'fullScaffold=false' so append entries already tracked in the lock are "
-            . "skipped; flipping the flag to 'true' would re-apply the stub and duplicate content across composer "
-            . 'update invocations.',
+            "'onPostUpdate' must dispatch with 'fullScaffold=false' so locked append entries are skipped.",
         );
     }
 

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -52,8 +52,7 @@ final class ScaffolderTest extends TestCase
         self::assertStringContainsString(
             'Provider "yii2-extensions/missing" is not installed',
             $io->getOutput(),
-            'Allowed providers that Composer did not install must emit a clear skip message so typos in '
-            . "'allowed-packages' are noticed.",
+            "Allowed providers not installed by Composer must emit a skip message so 'allowed-packages' typos are noticed.",
         );
     }
 
@@ -131,11 +130,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        /**
-         * An allowlist of `['safe/provider']` authorizes only that provider; when the actual provider is
-         * `yii2-extensions/test`, the Applier will throw with "Package not allowed" inside apply(). That throw must be
-         * caught by the Scaffolder loop and reported via writeError.
-         */
+        // Allowlist names a different provider so 'apply()' throws "Package not allowed"; the loop must catch and log it.
         $builder->createStubFile('yii2-extensions/test', 'app.php', 'content');
 
         $provider = $this->makeProviderPackage(
@@ -163,8 +158,7 @@ final class ScaffolderTest extends TestCase
         self::assertStringContainsString(
             'Error applying "app.php"',
             $io->getOutput(),
-            'Applier exceptions must be caught per-destination, reported via writeError, and must not abort the rest '
-            . 'of the scaffold loop.',
+            'Applier exceptions must be caught per-destination and reported via writeError without aborting the loop.',
         );
     }
 
@@ -201,8 +195,7 @@ final class ScaffolderTest extends TestCase
         self::assertStringContainsString(
             'No allowed-packages configured',
             $io->getOutput(),
-            'Empty allowed-packages list (as opposed to missing scaffold extra) must emit the configured-but-empty '
-            . 'skip message.',
+            'Empty allowed-packages list must emit the configured-but-empty skip message.',
         );
     }
 
@@ -288,8 +281,7 @@ final class ScaffolderTest extends TestCase
         self::assertSame(
             ['version' => '2.0.0', 'path' => $expectedPath],
             $providerEntry,
-            'Provider entry must record both version and path (path stays absolute when vendor lives outside the '
-            . 'project root, as in this fixture); separators are normalized to forward slashes.',
+            'Provider entry must record both version and path (absolute when vendor is outside the project root).',
         );
     }
 
@@ -297,10 +289,6 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        /**
-         * Simulate the realistic layout where vendor is nested under the project root; the scaffolder must record a
-         * relative path so the committed lock stays stable across machines.
-         */
         $providerRootInsideProject = $builder->getProjectRoot() . '/vendor/yii2-extensions/test';
 
         mkdir($providerRootInsideProject, 0777, recursive: true);
@@ -331,8 +319,7 @@ final class ScaffolderTest extends TestCase
         self::assertSame(
             ['version' => '2.0.0', 'path' => 'vendor/yii2-extensions/test'],
             $lockData['providers']['yii2-extensions/test'] ?? null,
-            'When the provider install path lies inside the project root, the lock must store a project-relative path '
-            . 'so the committed scaffold-lock.json stays stable across developer machines.',
+            'When the provider install path is inside the project root, the lock must store a project-relative path.',
         );
     }
 
@@ -502,14 +489,12 @@ final class ScaffolderTest extends TestCase
 
         self::assertFileExists(
             $builder->getProjectRoot() . '/app.php',
-            "When an earlier provider's manifest fails to load, the foreach must 'continue' to the next provider; "
-            . "replacing 'continue' with 'break' would abort the run and skip 'app.php'.",
+            "When an earlier provider's manifest fails to load, the foreach must 'continue' so 'app.php' is still written.",
         );
         self::assertSame(
             'good-content',
             file_get_contents($builder->getProjectRoot() . '/app.php'),
-            "The later provider's stub content must be applied verbatim after the earlier provider's manifest-load "
-            . 'failure is logged and skipped.',
+            "The later provider's stub must be applied after the earlier provider's manifest-load failure is logged.",
         );
     }
 
@@ -553,8 +538,7 @@ final class ScaffolderTest extends TestCase
         );
         self::assertFileExists(
             $builder->getProjectRoot() . '/app.php',
-            "After the uninstalled-provider skip message, the loop must 'continue' to the next allowed-package; "
-            . "replacing 'continue' with 'break' would leave 'app.php' unwritten.",
+            "After the uninstalled-provider skip, the loop must 'continue' so 'app.php' is still written.",
         );
     }
 
@@ -617,11 +601,7 @@ final class ScaffolderTest extends TestCase
             ],
         );
 
-        /*
-         * Craft an allowed-packages list whose first entry is a non-string integer (mixed-type payload) so it hits the
-         * '!is_string' continue-branch inside 'Scaffolder::scaffold'. A valid string entry follows and must still be
-         * processed.
-         */
+        // First entry is a non-string int so '!is_string' triggers 'continue'; the string entry after must still run.
         $root = self::createStub(PackageInterface::class);
         $root->method('getExtra')->willReturn(
             [
@@ -643,8 +623,7 @@ final class ScaffolderTest extends TestCase
 
         self::assertFileExists(
             $builder->getProjectRoot() . '/app.php',
-            "When the first allowed-packages entry is not a string, the loop must 'continue' to the next entry; "
-            . "replacing 'continue' with 'break' would halt the scan before 'yii2-extensions/good' is processed.",
+            "When the first allowed-packages entry is not a string, the loop must 'continue' so 'yii2-extensions/good' runs.",
         );
     }
 
@@ -673,10 +652,7 @@ final class ScaffolderTest extends TestCase
             'Byte-exact comparison must reject a prefix that only differs in casing.',
         );
 
-        /**
-         * case-insensitive branch is the Windows path; it must match regardless of casing. Covers the otherwise
-         * Linux-unreachable stripos branch used for NTFS compatibility.
-         */
+        // Case-insensitive branch covers the NTFS/Windows path otherwise unreachable on Linux.
         self::assertTrue(
             (bool) $method->invoke(null, '/project/vendor/foo', '/Project/', true),
             'Case-insensitive comparison must accept a prefix that only differs in casing.',
@@ -925,10 +901,7 @@ final class ScaffolderTest extends TestCase
 
         $userHash = (new Hasher())->hash($builder->getProjectRoot() . '/config.php');
 
-        /**
-         * pre-populate the lock with an outdated provider path but a correct file entry. The upcoming scaffold run must
-         * only set `$dirty = true` through the provider-path branch (L141) the preserve branch leaves `$dirty` alone.
-         */
+        // Pre-populate the lock with an outdated provider path; only the provider-path branch must mark '$dirty = true'.
         (new LockFile($builder->getProjectRoot()))->write(
             [
                 'providers' => [
@@ -968,8 +941,7 @@ final class ScaffolderTest extends TestCase
         self::assertSame(
             ['version' => '2.0.0', 'path' => $expectedPath],
             $providerEntry,
-            'Provider-entry updates alone must mark the lock dirty so the fresh {version, path} is persisted to disk; '
-            . 'path separators are normalized to forward slashes for cross-platform stability.',
+            'Provider-entry updates alone must mark the lock dirty so the fresh {version, path} is persisted to disk.',
         );
     }
 

--- a/tests/providers/DefaultExcludesProvider.php
+++ b/tests/providers/DefaultExcludesProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\scaffold\tests\providers;
+
+/**
+ * Data provider for {@see \yii\scaffold\tests\unit\Manifest\DefaultExcludesTest} test cases.
+ *
+ * Provides representative input/output pairs for {@see \yii\scaffold\Manifest\DefaultExcludes} matching.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.1
+ */
+final class DefaultExcludesProvider
+{
+    /**
+     * @phpstan-return list<array{0: string}>
+     */
+    public static function excludedPaths(): array
+    {
+        return [
+            ['composer.json'],
+            ['composer.lock'],
+            ['vendor/autoload.php'],
+            ['vendor/nested/pkg/file.php'],
+            ['.git/HEAD'],
+            ['.github/workflows/ci.yml'],
+            ['.gitattributes'],
+            ['.gitignore'],
+            ['tests/unit/SomeTest.php'],
+            ['tests/functional/deep/Fixture.php'],
+            ['phpunit.xml'],
+            ['phpunit.xml.dist'],
+            ['.phpunit.cache/foo'],
+            ['phpstan.neon'],
+            ['phpstan.neon.dist'],
+            ['phpstan.cache/bar'],
+            ['infection.json5'],
+            ['infection.log'],
+            ['.editorconfig'],
+            ['.php-cs-fixer.php'],
+            ['.php-cs-fixer.dist.php'],
+            ['ecs.php'],
+            ['psalm.xml'],
+            ['README.md'],
+            ['CHANGELOG.md'],
+            ['LICENSE'],
+            ['docs/providers.md'],
+            ['scaffold.json'],
+            ['scaffold-lock.json'],
+            ['runtime/cache/foo'],
+            ['runtime/.gitignore'],
+        ];
+    }
+
+    /**
+     * @phpstan-return list<array{0: string}>
+     */
+    public static function includedPaths(): array
+    {
+        return [
+            ['src/controllers/SiteController.php'],
+            ['src/models/User.php'],
+            ['config/params.php'],
+            ['config/web.php'],
+            ['migrations/M2024_CreateUserTable.php'],
+            ['public/index.php'],
+            ['public/assets/.gitkeep'],
+            ['yii'],
+            ['rbac/items.php'],
+            ['resources/mail/layouts/html.php'],
+        ];
+    }
+
+    /**
+     * @phpstan-return list<array{0: string}>
+     */
+    public static function nonPrunableDirectories(): array
+    {
+        return [
+            ['src'],
+            ['config'],
+            ['migrations'],
+            ['public'],
+            ['rbac'],
+            ['resources'],
+            ['vendor/bin'],
+            ['.git/hooks'],
+            ['tests/unit'],
+            ['docs/nested'],
+            [''],
+        ];
+    }
+
+    /**
+     * @phpstan-return list<array{0: string}>
+     */
+    public static function prunableDirectories(): array
+    {
+        return [
+            ['vendor'],
+            ['.git'],
+            ['.github'],
+            ['tests'],
+            ['.phpunit.cache'],
+            ['phpunit.cache'],
+            ['phpstan.cache'],
+            ['.infection'],
+            ['docs'],
+            ['runtime'],
+        ];
+    }
+}

--- a/tests/unit/Console/ApplicationTest.php
+++ b/tests/unit/Console/ApplicationTest.php
@@ -61,8 +61,7 @@ final class ApplicationTest extends TestCase
     {
         self::assertNotEmpty(
             (new Application())->getVersion(),
-            "'Application::getVersion()' must always return a non-empty string so 'vendor/bin/scaffold --version' "
-            . 'renders a meaningful value regardless of how the plugin was installed.',
+            "'Application::getVersion()' must always return a non-empty string for 'vendor/bin/scaffold --version'.",
         );
     }
 
@@ -86,8 +85,7 @@ final class ApplicationTest extends TestCase
         self::assertSame(
             $prettyVersion,
             Application::resolveVersion(Application::NAME),
-            "'Application::resolveVersion()' must return the exact Composer 'pretty_version' for an installed "
-            . 'package, not the hard-coded fallback.',
+            "'Application::resolveVersion()' must return the Composer 'pretty_version' for an installed package.",
         );
     }
 }

--- a/tests/unit/Console/Command/StatusCommandTest.php
+++ b/tests/unit/Console/Command/StatusCommandTest.php
@@ -134,8 +134,7 @@ final class StatusCommandTest extends TestCase
         self::assertSame(
             Command::FAILURE,
             $exitCode,
-            "When 'getcwd()' returns 'false', the command must fail fast instead of propagating an empty "
-            . 'project root.',
+            "When 'getcwd()' returns 'false', the command must fail fast instead of propagating an empty project root.",
         );
         self::assertStringContainsString(
             'Unable to determine current working directory',

--- a/tests/unit/Console/SymfonyOutputWriterTest.php
+++ b/tests/unit/Console/SymfonyOutputWriterTest.php
@@ -31,8 +31,7 @@ final class SymfonyOutputWriterTest extends TestCase
         self::assertSame(
             'plain <output> fallback' . PHP_EOL,
             $output->fetch(),
-            "When the wrapped 'OutputInterface' is not a 'ConsoleOutputInterface', stderr writes must fall back to "
-            . "the primary output (still preserving raw bytes) and append a single trailing newline via 'writeln'.",
+            "Without 'ConsoleOutputInterface', stderr writes must fall back to the primary output with a trailing newline.",
         );
     }
 
@@ -54,8 +53,7 @@ final class SymfonyOutputWriterTest extends TestCase
         self::assertSame(
             'error <bold>line</bold>' . PHP_EOL,
             $swapped->fetch(),
-            "A 'ConsoleOutputInterface' instance must route 'writeStderr' through 'getErrorOutput()' and preserve "
-            . 'any angle-bracket tokens verbatim while still appending a single trailing newline.',
+            "'writeStderr' must route through 'getErrorOutput()' and preserve angle-bracket tokens verbatim.",
         );
     }
     public function testWriteStdoutEmitsAngleBracketTokensVerbatimWithoutFormatterInterpretation(): void
@@ -67,9 +65,7 @@ final class SymfonyOutputWriterTest extends TestCase
         self::assertSame(
             '<?php echo $user; ?>' . PHP_EOL,
             $output->fetch(),
-            'Angle-bracket tokens inside a stdout write must survive verbatim instead of being interpreted as '
-            . "Symfony formatter tags (a plain 'write()' call would throw 'InvalidArgumentException' or strip the "
-            . 'tokens).',
+            'Angle-bracket tokens inside a stdout write must survive verbatim without Symfony formatter interpretation.',
         );
     }
 
@@ -82,8 +78,7 @@ final class SymfonyOutputWriterTest extends TestCase
         self::assertSame(
             '<info>hello</info>' . PHP_EOL,
             $output->fetch(),
-            'Symfony-style tags in service output must be written literally (no ANSI codes applied) even when the '
-            . "underlying 'OutputInterface' has decoration enabled.",
+            'Symfony-style tags must be written literally (no ANSI codes) even when decoration is enabled.',
         );
     }
 

--- a/tests/unit/Console/VendorDirResolverTest.php
+++ b/tests/unit/Console/VendorDirResolverTest.php
@@ -193,8 +193,7 @@ final class VendorDirResolverTest extends TestCase
         self::assertSame(
             'C:\\opt\\vendor',
             VendorDirResolver::resolve($this->tempDir),
-            "An absolute Windows path ('C:\\\\opt\\\\vendor') must be used verbatim without being joined to the "
-            . 'project root.',
+            "An absolute Windows path ('C:\\\\opt\\\\vendor') must be used verbatim without joining to the project root.",
         );
     }
 
@@ -205,8 +204,7 @@ final class VendorDirResolverTest extends TestCase
         self::assertSame(
             $this->tempDir . '/C:vendor',
             VendorDirResolver::resolve($this->tempDir),
-            "Windows drive-relative 'C:vendor' (no separator after the drive letter) is not absolute and must be "
-            . 'resolved against the project root.',
+            "Windows drive-relative 'C:vendor' (no separator after the drive letter) must be resolved under the root.",
         );
     }
 
@@ -217,8 +215,7 @@ final class VendorDirResolverTest extends TestCase
         self::assertSame(
             'C:\\',
             VendorDirResolver::resolve($this->tempDir),
-            "The drive root 'C:\\\\' must keep its trailing separator so it stays absolute; stripping it would "
-            . "turn it into the drive-relative 'C:' token.",
+            "The drive root 'C:\\\\' must keep its trailing separator to stay absolute (not drive-relative 'C:').",
         );
     }
 

--- a/tests/unit/Manifest/DefaultExcludesTest.php
+++ b/tests/unit/Manifest/DefaultExcludesTest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace yii\scaffold\tests\unit\Manifest;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use yii\scaffold\Manifest\DefaultExcludes;
+use yii\scaffold\tests\providers\DefaultExcludesProvider;
 
 /**
  * Unit tests for {@see DefaultExcludes} built-in exclusion patterns.
+ *
+ * {@see DefaultExcludesProvider} for test case data providers.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -18,105 +22,7 @@ use yii\scaffold\Manifest\DefaultExcludes;
 #[Group('manifest')]
 final class DefaultExcludesTest extends TestCase
 {
-    /**
-     * @return list<array{0: string}>
-     */
-    public static function excludedPathProvider(): array
-    {
-        return [
-            ['composer.json'],
-            ['composer.lock'],
-            ['vendor/autoload.php'],
-            ['vendor/nested/pkg/file.php'],
-            ['.git/HEAD'],
-            ['.github/workflows/ci.yml'],
-            ['.gitattributes'],
-            ['.gitignore'],
-            ['tests/unit/SomeTest.php'],
-            ['tests/functional/deep/Fixture.php'],
-            ['phpunit.xml'],
-            ['phpunit.xml.dist'],
-            ['.phpunit.cache/foo'],
-            ['phpstan.neon'],
-            ['phpstan.neon.dist'],
-            ['phpstan.cache/bar'],
-            ['infection.json5'],
-            ['infection.log'],
-            ['.editorconfig'],
-            ['.php-cs-fixer.php'],
-            ['.php-cs-fixer.dist.php'],
-            ['ecs.php'],
-            ['psalm.xml'],
-            ['README.md'],
-            ['CHANGELOG.md'],
-            ['LICENSE'],
-            ['docs/providers.md'],
-            ['scaffold.json'],
-            ['scaffold-lock.json'],
-            ['runtime/cache/foo'],
-            ['runtime/.gitignore'],
-        ];
-    }
-
-    /**
-     * @return list<array{0: string}>
-     */
-    public static function includedPathProvider(): array
-    {
-        return [
-            ['src/controllers/SiteController.php'],
-            ['src/models/User.php'],
-            ['config/params.php'],
-            ['config/web.php'],
-            ['migrations/M2024_CreateUserTable.php'],
-            ['public/index.php'],
-            ['public/assets/.gitkeep'],
-            ['yii'],
-            ['rbac/items.php'],
-            ['resources/mail/layouts/html.php'],
-        ];
-    }
-
-    /**
-     * @return list<array{0: string}>
-     */
-    public static function nonPrunableDirectoryProvider(): array
-    {
-        return [
-            ['src'],
-            ['config'],
-            ['migrations'],
-            ['public'],
-            ['rbac'],
-            ['resources'],
-            ['vendor/bin'],
-            ['.git/hooks'],
-            ['tests/unit'],
-            ['docs/nested'],
-            [''],
-        ];
-    }
-
-    /**
-     * @return list<array{0: string}>
-     */
-    public static function prunableDirectoryProvider(): array
-    {
-        return [
-            ['vendor'],
-            ['.git'],
-            ['.github'],
-            ['tests'],
-            ['.phpunit.cache'],
-            ['phpunit.cache'],
-            ['phpstan.cache'],
-            ['.infection'],
-            ['docs'],
-            ['runtime'],
-        ];
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('excludedPathProvider')]
+    #[DataProviderExternal(DefaultExcludesProvider::class, 'excludedPaths')]
     public function testExcludedPathMatchesDefaultExcludes(string $path): void
     {
         self::assertTrue(
@@ -125,7 +31,7 @@ final class DefaultExcludesTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('includedPathProvider')]
+    #[DataProviderExternal(DefaultExcludesProvider::class, 'includedPaths')]
     public function testIncludedPathDoesNotMatchDefaultExcludes(string $path): void
     {
         self::assertFalse(
@@ -134,13 +40,12 @@ final class DefaultExcludesTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('nonPrunableDirectoryProvider')]
+    #[DataProviderExternal(DefaultExcludesProvider::class, 'nonPrunableDirectories')]
     public function testNonPrunableDirectoryIsNotMatchedByMatchesDirectory(string $relativeDir): void
     {
         self::assertFalse(
             DefaultExcludes::matchesDirectory($relativeDir),
-            "'{$relativeDir}' must not be pruned: no default pattern of the form '{$relativeDir}/**' excludes every "
-            . 'possible descendant.',
+            "'{$relativeDir}' must not be prunable: no default pattern '{$relativeDir}/**' excludes every descendant.",
         );
     }
 
@@ -152,13 +57,12 @@ final class DefaultExcludesTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('prunableDirectoryProvider')]
+    #[DataProviderExternal(DefaultExcludesProvider::class, 'prunableDirectories')]
     public function testPrunableDirectoryIsMatchedByMatchesDirectory(string $relativeDir): void
     {
         self::assertTrue(
             DefaultExcludes::matchesDirectory($relativeDir),
-            "'{$relativeDir}' must be prunable: a default pattern of the form '{$relativeDir}/**' excludes every "
-            . 'possible descendant, so descent can be safely skipped.',
+            "'{$relativeDir}' must be prunable: pattern '{$relativeDir}/**' excludes every descendant.",
         );
     }
 }

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -108,9 +108,6 @@ final class ManifestExpanderTest extends TestCase
 
     public function testExpandContinuesToNextCopyEntryAfterDeduplicatingRepeatedFile(): void
     {
-        // Listing the same file twice seeds the dedup map on iter 1 and routes iter 2 through the 'isset' branch.
-        // A third entry after the duplicate proves the outer loop resumes: replacing 'continue' with 'break' on the
-        // dedup branch would exit the foreach and strip 'other.txt' from the output.
         $this->seedFile('yii');
         $this->seedFile('other.txt');
 
@@ -125,15 +122,12 @@ final class ManifestExpanderTest extends TestCase
         self::assertContains(
             'other.txt',
             $this->destinations($mappings),
-            "After a duplicate file entry hits the dedup branch, the outer loop must 'continue' so subsequent copy "
-            . "entries still process; replacing the 'continue' with 'break' would drop 'other.txt' from the output.",
+            "After a duplicate file entry hits the dedup branch, the outer loop must 'continue' to process subsequent entries.",
         );
     }
 
     public function testExpandContinuesToNextCopyEntryAfterWalkingDirectory(): void
     {
-        // Two sibling directories in 'copy[]' prove the outer loop resumes after a successful dir walk: replacing the
-        // trailing 'continue' with 'break' would exit the foreach after walking 'dir1' and strip 'dir2/b.txt' out.
         $this->seedFile('dir1/a.txt');
         $this->seedFile('dir2/b.txt');
 
@@ -148,19 +142,13 @@ final class ManifestExpanderTest extends TestCase
         self::assertContains(
             'dir2/b.txt',
             $this->destinations($mappings),
-            "After walking the first directory, the outer loop must 'continue' so the next entry is walked too; "
-            . "replacing the 'continue' with 'break' would drop 'dir2/b.txt' from the output.",
+            "After walking the first directory, the outer loop must 'continue' so the next entry is walked too.",
         );
     }
 
     public function testExpandDedupContinueDoesNotBreakDirectoryWalk(): void
     {
-        /*
-         * Alphabetic iteration guarantees 'a.php' is processed first by the walk. Pre-adding it as an explicit file
-         * entry in 'copy[]' seeds the dedup map for that key; the walk then hits 'a.php', finds it already seen,
-         * and must 'continue' to iterate 'b.php' / 'c.php'. Replacing 'continue' with 'break' would halt the walk
-         * and strip both follow-up destinations from the output.
-         */
+        // Pre-adding 'a.php' as an explicit entry seeds the dedup map so the walk must 'continue' onto 'b.php' / 'c.php'.
         $this->seedFile('a.php');
         $this->seedFile('b.php');
         $this->seedFile('c.php');
@@ -229,9 +217,6 @@ final class ManifestExpanderTest extends TestCase
 
     public function testExpandNormalisesTrailingSeparatorInCopyDirectoryEntry(): void
     {
-        // A trailing '/' on a dir entry used to make the walk skip one character from each filename and emit destinations
-        // like 'src//ile.php'. The 'rtrim' in both the dir-prefix and the absolute-prefix derivation keep the output
-        // identical whether the provider writes 'src' or 'src/'.
         $this->seedFile('src/controllers/SiteController.php');
 
         $mappings = $this->expand(
@@ -245,19 +230,14 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['src/controllers/SiteController.php'],
             $this->destinations($mappings),
-            "A trailing '/' on a 'copy' directory entry must produce the same destinations as the un-slashed form; the "
-            . 'expander rtrims trailing separators before deriving paths so no character is dropped and no double slash '
-            . 'appears.',
+            "A trailing '/' on a 'copy' directory entry must produce the same destinations as the un-slashed form.",
         );
     }
 
     public function testExpandPrunesDefaultExcludedDirectoriesWithoutDescendingIntoThem(): void
     {
-        // Behavioral proof of descent pruning on POSIX non-root: 'chmod 0' on 'vendor' makes 'opendir()' throw
-        // 'UnexpectedValueException', so the walk only completes when the recursive filter rejects descent BEFORE
-        // the iterator attempts to read the subtree. Windows ignores POSIX mode bits and root bypasses them, so on
-        // those environments the chmod is a no-op; the assertion still holds there via file-level exclude matching,
-        // but the descent-prevention proof is only meaningful when the platform and user honour mode bits.
+        // Descent-pruning proof requires POSIX mode bits to be honoured: 'chmod 0' on 'vendor' must deny 'opendir()'
+        // so the walk only completes when the recursive filter rejects descent BEFORE reading the subtree.
         $this->skipUnlessChmodDeniesDirectoryReads();
         $this->seedFile('src/main.php');
         $this->seedFile('vendor/pkg/bogus.php');
@@ -279,16 +259,13 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['src/main.php'],
             $this->destinations($mappings),
-            "Default-excluded directories must be pruned BEFORE descent; otherwise an unreadable 'vendor/' would "
-            . 'derail the walk instead of being silently skipped.',
+            "Default-excluded directories must be pruned BEFORE descent; otherwise an unreadable 'vendor/' would derail it.",
         );
     }
 
     public function testExpandPrunesUserExcludedDirectoriesWithoutDescendingIntoThem(): void
     {
-        // Same behavioral proof as the default-exclude companion: requires a platform and user that honour POSIX
-        // mode bits so 'chmod 0' actually denies reads. On Windows or root the chmod is a no-op and this test
-        // degrades to a file-level exclusion check; the guard below skips it explicitly in those cases.
+        // Requires POSIX mode bits: Windows and root ignore 'chmod 0', which would reduce the test to file-level exclusion.
         $this->skipUnlessChmodDeniesDirectoryReads();
         $this->seedFile('src/main.php');
         $this->seedFile('secrets/keys.txt');
@@ -310,16 +287,13 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['src/main.php'],
             $this->destinations($mappings),
-            "User-exclude patterns of form 'X/**' must prune the directory BEFORE descent; otherwise an unreadable "
-            . "'secrets/' subtree would derail the walk instead of being silently skipped.",
+            "User-exclude patterns 'X/**' must prune directories BEFORE descent; otherwise unreadable subtrees derail the walk.",
         );
     }
 
     public function testExpandResolvesExactMatchInModesAndShortCircuitsGlobLoop(): void
     {
-        // Declaration order matters: the broader glob 'config/*.php' is declared BEFORE the exact path; the default
-        // code path short-circuits via 'isset($modes[$relative])' returning Replace. Removing that early return
-        // would fall through to the foreach and let the first-declared glob win with Preserve, a distinct mode.
+        // Declaration order is deliberate: the glob is declared BEFORE the exact path to exercise the 'isset' short-circuit.
         $this->seedFile('config/params.php');
 
         $mappings = $this->expand(
@@ -336,8 +310,7 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             FileMode::Replace,
             $mappings[0]->mode ?? null,
-            'Exact path match must win over a preceding-but-also-matching glob; removing the early return from the '
-            . "'isset' check flips the result to the glob's mode.",
+            "Exact path match must win over a preceding-but-also-matching glob via the 'isset' early return.",
         );
     }
 
@@ -386,8 +359,7 @@ final class ManifestExpanderTest extends TestCase
 
     public function testExpandReturnsWalkResultsInAlphabeticallySortedOrder(): void
     {
-        // Seed files in reverse-alphabetic creation order so the directory's dirent order likely reverses the
-        // desired sequence; the walk must still produce alphabetic ordering, which only holds when 'sort' runs.
+        // Seed in reverse-alphabetic order so the dirent order cannot accidentally match the expected sorted output.
         $this->seedFile('zzz.php');
         $this->seedFile('mmm.php');
         $this->seedFile('aaa.php');
@@ -405,16 +377,12 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['aaa.php', 'mmm.php', 'zzz.php'],
             $rawOrder,
-            "Walk results must be sorted alphabetically so 'scaffold-lock.json' stays deterministic; removing the "
-            . "'sort()' call would leak filesystem-dependent ordering into the lock and make git diffs noisy.",
+            "Walk results must be sorted alphabetically so 'scaffold-lock.json' stays deterministic across filesystems.",
         );
     }
 
     public function testExpandSkipsExcludedFilesAndContinuesToRemainingEntries(): void
     {
-        // An exclude pattern that drops one file while keeping its sibling proves the walk resumes after the skip:
-        // replacing the 'continue' in the exclude branch with 'break' would exit the foreach on the first excluded
-        // entry and strip the surviving sibling from the output.
         $this->seedFile('src/drop.txt');
         $this->seedFile('src/keep.txt');
 
@@ -429,8 +397,7 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['src/keep.txt'],
             $this->destinations($mappings),
-            "After an excluded file hits the skip branch, the walk must 'continue' so remaining files still process; "
-            . "replacing the 'continue' with 'break' would drop 'src/keep.txt' from the output.",
+            "After an excluded file hits the skip branch, the walk must 'continue' so remaining files still process.",
         );
     }
 
@@ -463,8 +430,7 @@ final class ManifestExpanderTest extends TestCase
         self::assertSame(
             ['runtime/.gitignore'],
             $this->destinations($mappings),
-            'An explicit file entry under a default-excluded directory must still ship because explicit entries bypass '
-            . 'the default excludes.',
+            'An explicit file entry under a default-excluded directory must still ship; explicit entries bypass excludes.',
         );
     }
 

--- a/tests/unit/Manifest/ManifestLoaderTest.php
+++ b/tests/unit/Manifest/ManifestLoaderTest.php
@@ -30,9 +30,7 @@ final class ManifestLoaderTest extends TestCase
 
     public function testLoadAcceptsExternalManifestPathContainingColonInNonLeadingPosition(): void
     {
-        // Guards the '^' anchor in the drive-letter regex '/^[A-Za-z]:/' inside 'readExternal': without the anchor,
-        // ordinary relative paths that contain a letter-colon anywhere (stream wrappers, namespace separators, etc.)
-        // would be wrongly rejected as absolute Windows paths.
+        // Pins the '^' anchor in '/^[A-Za-z]:/': non-leading colons (stream wrappers, namespaces) must not be rejected.
         $manifest = ['copy' => ['src']];
 
         $this->seedFile('src/Foo.php');
@@ -50,8 +48,7 @@ final class ManifestLoaderTest extends TestCase
         self::assertCount(
             1,
             $result,
-            "A manifest path whose non-leading segment contains '[A-Za-z]:' must load normally; the drive-letter "
-            . "check must only fire when the WHOLE path starts with '[A-Za-z]:'.",
+            "A manifest path whose non-leading segment contains '[A-Za-z]:' must load; the drive-letter check fires only on leading.",
         );
     }
 
@@ -108,8 +105,6 @@ final class ManifestLoaderTest extends TestCase
 
     public function testLoadExternalManifestPreservesEveryDeclaredKey(): void
     {
-        // Seed two copy roots AND multiple exclude / mode entries so any silent truncation of the decoded manifest
-        // (for example, keeping only the first array element) would drop assertions that depend on the full structure.
         $this->seedFile('src/Foo.php');
         $this->seedFile('config/params.php');
         $this->seedFile('config/web.php');
@@ -206,10 +201,7 @@ final class ManifestLoaderTest extends TestCase
 
     public function testLoadThrowsWhenExternalManifestCannotBeRead(): void
     {
-        // Forcing 'file_get_contents' to 'false' isolates the narrow error path where 'is_file()' succeeds but reading
-        // the file fails (for example, a race in which the file is unlinked between the existence check and the read,
-        // or a filesystem quota hit mid-read). The mocker intercepts the call in the 'yii\\scaffold\\Manifest'
-        // namespace so the production code returns the expected I/O failure without touching real filesystem state.
+        // Forces 'file_get_contents' to 'false' to cover the race where 'is_file()' succeeds but reading then fails.
         $manifestPath = "{$this->tempDir}/scaffold.json";
 
         file_put_contents($manifestPath, '{}');

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -21,16 +21,13 @@ final class ManifestSchemaTest extends TestCase
 {
     public function testValidateAcceptsCopyEntryContainingColonInNonLeadingPosition(): void
     {
-        // The '^' anchor in the drive-letter regex '/^[A-Za-z]:/' is load-bearing: without it, any letter followed by
-        // a colon anywhere in the string would trigger the absolute-path rejection, blocking legitimate relative
-        // paths that happen to include ':' (namespace separators, resource fork addresses, stream wrappers, etc.).
+        // Pins the '^' anchor in '/^[A-Za-z]:/': non-leading colons (namespaces, stream wrappers) must not be rejected.
         $result = (new ManifestSchema())->validate(['copy' => ['some/module:file.php']]);
 
         self::assertSame(
             ['some/module:file.php'],
             $result['copy'],
-            'A colon that is not the second character of the path must be treated as a literal filename byte; the '
-            . "drive-letter check must only fire when the path STARTS with '[A-Za-z]:'.",
+            'A colon past the second character must be treated as a literal byte; the drive-letter check fires only on leading.',
         );
     }
 
@@ -62,8 +59,7 @@ final class ManifestSchemaTest extends TestCase
         self::assertSame(
             ['first.php', 'second.php', 'third.php'],
             $result['exclude'],
-            "Every 'exclude[]' entry must round-trip through the validator; dropping entries would hide patterns that "
-            . 'the expander must apply.',
+            "Every 'exclude[]' entry must round-trip through the validator; dropping entries hides expander patterns.",
         );
     }
 

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -356,8 +356,7 @@ final class LockFileTest extends TestCase
         );
         self::assertFileDoesNotExist(
             $tmp,
-            "After 'rename' fails, the cleanup branch must 'unlink' the orphan '.tmp' sidecar so repeated write "
-            . 'attempts never see stale partial content; skipping the unlink leaks the sidecar to disk.',
+            "After 'rename' fails, the cleanup branch must 'unlink' the orphan '.tmp' sidecar to avoid stale content.",
         );
     }
 

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -113,10 +113,7 @@ final class AppendModeTest extends TestCase
     {
         $this->makeSourceFile('x');
 
-        /**
-         * `default: true` makes the mocker unconditionally fail every `file_get_contents` in the Modes namespace no
-         * strict argument matching, so the test is immune to future changes in how the mode assembles paths.
-         */
+        // 'default: true' fails every 'file_get_contents' in the Modes namespace, independent of how paths are assembled.
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Modes',
             'file_get_contents',

--- a/tests/unit/Scaffold/Modes/PrependModeTest.php
+++ b/tests/unit/Scaffold/Modes/PrependModeTest.php
@@ -151,13 +151,7 @@ final class PrependModeTest extends TestCase
 
         file_put_contents($sourcePath, 'source');
 
-        /**
-         * `PrependMode::apply()` calls `file_get_contents` twice — once for the source, once for the destination. This
-         * test must exercise ONLY the destination branch, so we cannot use `default: true` here (it would trip the
-         * source branch first). A callable-as-result with `default: true` also does not work because the mocker stores
-         * defaults verbatim and returns them without invocation. Strict argument matching on the destination path is
-         * the only mechanism left for this narrow case.
-         */
+        // 'PrependMode' reads source AND destination; strict arg-matching is required so only the destination branch fails.
         $destBasename = 'output.txt';
 
         MockerState::addCondition(

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -158,9 +158,7 @@ final class PreserveModeTest extends TestCase
             self::assertSame(
                 0755,
                 fileperms("{$this->tempDir}/project/output.txt") & 0777,
-                "After 'PreserveMode::apply' copies the stub, it must invoke 'syncPermissions' so the destination "
-                . "inherits the source executable bit (0755 here); without 'syncPermissions' the file would keep the "
-                . "umask-derived 0644 that 'copy()' produces, breaking scaffolded CLI stubs.",
+                "After 'PreserveMode::apply' copies the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {
             umask($oldUmask);

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -170,9 +170,7 @@ final class ReplaceModeTest extends TestCase
             self::assertSame(
                 0755,
                 fileperms("{$this->tempDir}/project/output.txt") & 0777,
-                "After 'ReplaceMode::apply' copies the stub, it must invoke 'syncPermissions' so the destination "
-                . "inherits the source executable bit (0755 here); without 'syncPermissions' the file would keep the "
-                . "umask-derived 0644 that 'copy()' produces, breaking scaffolded CLI stubs.",
+                "After 'ReplaceMode::apply' copies the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {
             umask($oldUmask);
@@ -289,7 +287,8 @@ final class ReplaceModeTest extends TestCase
      * Helper to create a source file for testing.
      *
      * @param string $content Content to write to the source file, defaulting to 'stub content'.
-     * @param string $relative Relative path of the source file within the provider directory, defaulting to 'stubs/source.txt'.
+     * @param string $relative Relative path of the source file within the provider directory, defaulting to
+     * 'stubs/source.txt'.
      */
     private function makeSourceFile(string $content = 'stub content', string $relative = 'stubs/source.txt'): void
     {

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -110,8 +110,7 @@ final class PathResolverTest extends TestCase
         self::assertGreaterThanOrEqual(
             2,
             $isDirCalls,
-            "'is_dir' must be consulted again after 'mkdir' returns 'false' so a concurrent creation is not treated "
-            . 'as failure.',
+            "'is_dir' must be rechecked after 'mkdir' returns 'false' so a concurrent creation is not treated as failure.",
         );
     }
 
@@ -173,12 +172,6 @@ final class PathResolverTest extends TestCase
 
     public function testResolveProviderRootDetectsUncLikePathAsAbsoluteViaBackslashPrefix(): void
     {
-        /*
-         * recordedPath starts with `\` (UNC-style). Default isAbsolute is true via the second 'str_starts_with' in
-         * the OR chain; mutating the '||' between the first two operands to '&&' with the third operand folds the
-         * detection into '(starts_with('\\') && preg_match drive-letter)', which is false for pure UNC paths — the
-         * path is then misclassified as relative and joined under 'projectRoot', landing outside vendor.
-         */
         $vendor = PathResolver::realpathOrFallback($this->tempDir);
 
         $result = PathResolver::resolveProviderRoot(
@@ -190,19 +183,12 @@ final class PathResolverTest extends TestCase
 
         self::assertNotNull(
             $result['warning'],
-            "A UNC-like recordedPath starting with '\\' must stay absolute and land outside vendor, emitting a "
-            . "warning; the '||' disjunction on the 'str_starts_with' operands is what keeps it classified correctly.",
+            "A UNC-like recordedPath starting with '\\' must stay absolute and land outside vendor, emitting a warning.",
         );
     }
 
     public function testResolveProviderRootDoesNotClassifyRelativePathContainingDriveLetterInMiddleAsAbsolute(): void
     {
-        /*
-         * recordedPath 'foo/C:/bar' is relative but carries a drive-letter substring; only the regex '^' anchor
-         * keeps it classified as relative. Default: joined under projectRoot and stays inside vendor → no warning.
-         * Without '^' the mutant flips isAbsolute to true, '$expanded' becomes 'foo/C:/bar' verbatim (relative), the
-         * realpath fallback leaves it with no vendor prefix, and containment fails → warning.
-         */
         $vendor = PathResolver::realpathOrFallback($this->tempDir);
 
         $result = PathResolver::resolveProviderRoot(
@@ -214,8 +200,7 @@ final class PathResolverTest extends TestCase
 
         self::assertNull(
             $result['warning'],
-            "A relative recordedPath with a drive-letter substring must stay classified as relative; the regex '^' "
-            . 'anchor keeps it joined under projectRoot so it lands inside vendor without warning.',
+            "A relative recordedPath with a drive-letter substring must stay relative; '^' anchor keeps it under projectRoot.",
         );
     }
 
@@ -234,8 +219,7 @@ final class PathResolverTest extends TestCase
         self::assertSame(
             realpath($vendor) . DIRECTORY_SEPARATOR . 'pkg/name',
             $result['root'],
-            'When the lock-recorded path escapes vendor, resolveProviderRoot must fall back to the vendor-derived '
-            . 'path.',
+            'When the lock-recorded path escapes vendor, resolveProviderRoot must fall back to the vendor-derived path.',
         );
         self::assertNotNull(
             $result['warning'],
@@ -276,8 +260,7 @@ final class PathResolverTest extends TestCase
 
         self::assertNotNull(
             $result['warning'],
-            'A lock path outside vendor that only shares a string prefix must emit a warning and fall back to the '
-            . 'default root.',
+            'A lock path outside vendor that only shares a string prefix must warn and fall back to the default root.',
         );
     }
 
@@ -355,8 +338,7 @@ final class PathResolverTest extends TestCase
         self::assertSame(
             PathResolver::realpathOrFallback($this->tempDir) . DIRECTORY_SEPARATOR . 'pkg/name',
             $result['root'],
-            'When the lock record is missing or does not contain a path, resolveProviderRoot must fall back to the '
-            . 'default root (canonicalized via realpathOrFallback to match implementation behavior).',
+            'When the lock record lacks a path, resolveProviderRoot must fall back to the canonicalized default root.',
         );
         self::assertNull(
             $result['warning'],
@@ -406,8 +388,7 @@ final class PathResolverTest extends TestCase
             self::assertSame(
                 0755,
                 fileperms($destination) & 0777,
-                "Under a permissive '0022' umask, 'syncPermissions()' must preserve the source executable bit so "
-                . 'scaffolded CLI stubs remain directly runnable.',
+                "Under a permissive '0022' umask, 'syncPermissions()' must preserve the source executable bit.",
             );
         } finally {
             umask($oldUmask);
@@ -437,8 +418,7 @@ final class PathResolverTest extends TestCase
             self::assertSame(
                 0700,
                 fileperms($destination) & 0777,
-                "Under a restrictive '0077' umask, 'syncPermissions()' must mask the source permissions and drop "
-                . 'group/other bits so security-restrictive setups are never silently widened.',
+                "Under a restrictive '0077' umask, 'syncPermissions()' must mask source perms and drop group/other bits.",
             );
         } finally {
             umask($oldUmask);
@@ -460,11 +440,7 @@ final class PathResolverTest extends TestCase
         chmod($source, 0640);
         chmod($destination, 0600);
 
-        /*
-         * A permissive '0000' umask isolates the `$perms & 0777` bitmask from the umask mask; any mutation that
-         * swaps `&` for `|` (widening 0640 to 0777 via bitwise OR) becomes observable without being masked out by
-         * the umask step that follows.
-         */
+        // '0000' umask isolates the `& 0777` mask from the umask step so `& → |` mutations are directly observable.
         $oldUmask = umask(0000);
 
         try {
@@ -473,9 +449,7 @@ final class PathResolverTest extends TestCase
             self::assertSame(
                 0640,
                 fileperms($destination) & 0777,
-                "Under a permissive '0000' umask the destination must land on exactly the source permissions (0640); "
-                . "mutating '\$perms & 0777' to '\$perms | 0777' widens to 0777 and this assertion fails, pinning the "
-                . 'bitmask intent.',
+                "Under a permissive '0000' umask, the destination must land on exactly the source permissions (0640).",
             );
         } finally {
             umask($oldUmask);
@@ -499,8 +473,7 @@ final class PathResolverTest extends TestCase
         self::assertSame(
             0644,
             fileperms($destination) & 0777,
-            "When 'fileperms()' on the source returns 'false' (missing/unreadable source), 'syncPermissions()' "
-            . 'must return early and leave the destination permissions untouched.',
+            "When 'fileperms()' returns 'false', 'syncPermissions()' must return early and leave the destination untouched.",
         );
     }
 

--- a/tests/unit/Scaffold/ScaffolderToProjectRelativeTest.php
+++ b/tests/unit/Scaffold/ScaffolderToProjectRelativeTest.php
@@ -44,10 +44,6 @@ final class ScaffolderToProjectRelativeTest extends TestCase
 
     public function testNormalizesBackslashSeparatorsInAbsolutePathBeforePrefixMatch(): void
     {
-        /*
-         * Pins the 'str_replace('\\', '/', $absolutePath)' normalization at line 263. Same idea as the projectRoot
-         * test, but on the package-path side.
-         */
         self::assertSame(
             'pkg',
             $this->call('/tmp/project/subdir\\pkg', '/tmp/project/subdir'),
@@ -56,11 +52,6 @@ final class ScaffolderToProjectRelativeTest extends TestCase
     }
     public function testNormalizesBackslashSeparatorsInProjectRootBeforePrefixMatch(): void
     {
-        /*
-         * Pins the 'str_replace('\\', '/', $projectRoot)' normalization at line 262. With a backslash in projectRoot,
-         * default normalizes both sides to forward-slashes → prefix match → returns relative 'pkg'. Without that
-         * str_replace the mutant keeps '\' in the needle, prefix-match fails, and the full absolute path is returned.
-         */
         self::assertSame(
             'pkg',
             $this->call('/tmp/project/subdir/pkg', '/tmp/project\\subdir'),
@@ -81,9 +72,7 @@ final class ScaffolderToProjectRelativeTest extends TestCase
         self::assertSame(
             '',
             $this->call('/tmp/project', '/tmp/project'),
-            "When the package path equals the project root exactly, 'toProjectRelative' must return an empty string; "
-            . "the boundary-enforcing '. \"/\"' concatenation on 'normalizedPath' guards this edge case and its "
-            . 'removal would return the full absolute path instead.',
+            "When the package path equals the project root exactly, 'toProjectRelative' must return an empty string.",
         );
     }
 
@@ -92,8 +81,7 @@ final class ScaffolderToProjectRelativeTest extends TestCase
         self::assertSame(
             '/outside/project/pkg',
             $this->call('/outside/project/pkg', '/tmp/project'),
-            'Package paths outside the project root must fall back to the normalized absolute path so the lock '
-            . 'still records a usable location.',
+            'Package paths outside the project root must fall back to the normalized absolute path.',
         );
     }
 
@@ -102,8 +90,7 @@ final class ScaffolderToProjectRelativeTest extends TestCase
         self::assertSame(
             '/other/location',
             $this->call('/other/location/', '/tmp/project'),
-            "When the package path lies outside the project root, the fallback must still 'rtrim' trailing separators "
-            . "so absolute lock paths are recorded without spurious trailing '/'.",
+            "When the package path is outside the project root, the fallback must 'rtrim' trailing separators.",
         );
     }
 
@@ -112,9 +99,7 @@ final class ScaffolderToProjectRelativeTest extends TestCase
         self::assertSame(
             'vendor/pkg',
             $this->call('/tmp/project/vendor/pkg', '/tmp/project/'),
-            "A trailing separator on the project root must be stripped before the prefix check; without 'rtrim' the "
-            . "doubled slash ('/tmp/project//') would miss the prefix and leak the absolute package path into the "
-            . 'lock.',
+            "A trailing separator on the project root must be stripped before the prefix check via 'rtrim'.",
         );
     }
 
@@ -123,8 +108,7 @@ final class ScaffolderToProjectRelativeTest extends TestCase
         self::assertSame(
             'vendor/pkg',
             $this->call('/tmp/project/vendor/pkg/', '/tmp/project'),
-            "A trailing separator on the relative segment (after 'substr') must be stripped so lock entries never "
-            . "record paths like 'vendor/pkg/'; the outer 'rtrim(substr(...), \"/\")' guards this.",
+            "A trailing separator on the relative segment (after 'substr') must be stripped via outer 'rtrim'.",
         );
     }
 

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -221,11 +221,7 @@ final class PathValidatorTest extends TestCase
 
     public function testNormalizePathStripsTrailingSeparatorFromCombinedResult(): void
     {
-        /*
-         * Pins the outer 'rtrim($combined, DIRECTORY_SEPARATOR)' at line 194: with a relative that ends in a
-         * separator, 'normalizePath' must trim it so downstream 'dirname' iterations and string comparisons work on
-         * a canonical absolute path. Exercised via reflection because 'normalizePath' is private.
-         */
+        // Private 'normalizePath' exercised via reflection: must 'rtrim' trailing separators from the combined result.
         $method = new ReflectionMethod(PathValidator::class, 'normalizePath');
 
         /** @var string $result */

--- a/tests/unit/Services/DiffServiceTest.php
+++ b/tests/unit/Services/DiffServiceTest.php
@@ -30,14 +30,12 @@ final class DiffServiceTest extends TestCase
         self::assertStringStartsNotWith(
             PHP_EOL,
             $diff,
-            "The concatenated diff must not begin with PHP_EOL; 'implode(PHP_EOL, ...)' inserts separators between "
-            . 'lines only, not at the beginning.',
+            "The concatenated diff must not begin with PHP_EOL; 'implode' inserts separators between lines only.",
         );
         self::assertStringEndsNotWith(
             PHP_EOL,
             $diff,
-            'The concatenated diff must not end with PHP_EOL; the trailing newline is appended by the OutputWriter '
-            . "when the diff is written via 'writeStdout', not by 'buildDiff' itself.",
+            "The concatenated diff must not end with PHP_EOL; the trailing newline is appended by 'writeStdout'.",
         );
     }
 
@@ -99,11 +97,7 @@ final class DiffServiceTest extends TestCase
 
     public function testBuildDiffTrimsAddedLinesOfTrailingNewlinesBeforeJoin(): void
     {
-        /*
-         * Use inputs that produce multiple added lines so mutating the 'rtrim' on added lines produces an observable
-         * doubled-newline at the 'implode' join boundary. A single added line would hide the mutation behind the absent
-         * trailing separator.
-         */
+        // Multiple added lines are required so an 'rtrim' mutation shows as a doubled newline at the 'implode' boundary.
         $diff = (new DiffService())->buildDiff('a', "a\nb\nc\n");
 
         self::assertStringNotContainsString(
@@ -114,8 +108,7 @@ final class DiffServiceTest extends TestCase
         self::assertStringContainsString(
             '+ b' . PHP_EOL . '+ c',
             $diff,
-            "Two consecutive added lines must be separated by exactly one PHP_EOL after the 'rtrim'; any additional "
-            . 'newline indicates the inner rtrim was bypassed.',
+            "Two consecutive added lines must be separated by exactly one PHP_EOL after the 'rtrim'.",
         );
     }
 
@@ -126,7 +119,7 @@ final class DiffServiceTest extends TestCase
         self::assertStringNotContainsString(
             '- b' . "\n" . PHP_EOL,
             $diff,
-            "Removed lines must be rtrimmed of trailing '\\n' before the 'implode(PHP_EOL, ...)' join on every platform.",
+            "Removed lines must be rtrimmed of trailing '\\n' before the 'implode' join on every platform.",
         );
         self::assertStringContainsString(
             '- b' . PHP_EOL . '- c',
@@ -142,7 +135,7 @@ final class DiffServiceTest extends TestCase
         self::assertStringNotContainsString(
             '  a' . "\n" . PHP_EOL,
             $diff,
-            "Unchanged lines must be rtrimmed of trailing '\\n' before the 'implode(PHP_EOL, ...)' join on every platform.",
+            "Unchanged lines must be rtrimmed of trailing '\\n' before the 'implode' join on every platform.",
         );
         self::assertStringContainsString(
             '  a' . PHP_EOL . '  b',
@@ -211,8 +204,7 @@ final class DiffServiceTest extends TestCase
         self::assertSame(
             0,
             $exitCode,
-            'A provider-path warning must be non-fatal — the diff command must fall back to the default provider '
-            . 'root and still return a success exit code.',
+            'A provider-path warning must be non-fatal: the command falls back to the default root and still succeeds.',
         );
         self::assertStringContainsString(
             'resolves outside vendor dir',
@@ -270,8 +262,7 @@ final class DiffServiceTest extends TestCase
         self::assertStringStartsNotWith(
             PHP_EOL,
             $out->stdoutBuffer,
-            "The 'No differences found' message must not be prefixed with PHP_EOL; the newline belongs after the "
-            . 'message.',
+            "The 'No differences found' message must not be prefixed with PHP_EOL; the newline belongs after it.",
         );
     }
 
@@ -508,12 +499,7 @@ final class DiffServiceTest extends TestCase
 
     public function testRunReturnsUnsafeDestinationErrorEvenWhenProviderRootAndSourceAreSafe(): void
     {
-        /*
-         * Seed a fully valid provider tree (providerRoot + stubs exist, source is relative and traversal-free) so
-         * 'validateSource' passes unconditionally. This isolates the 'validateDestination' call: removing it would let
-         * the unsafe '../escape.php' lock entry slip past without producing the 'Unsafe lock entry' diagnostic, so the
-         * assertion below pins its presence in the trust boundary.
-         */
+        // Valid provider tree so 'validateSource' passes unconditionally; isolates the 'validateDestination' guard.
         $providerRoot = "{$this->tempDir}/vendor/pkg/name";
 
         $this->ensureTestDirectory("{$providerRoot}/stubs");
@@ -555,19 +541,13 @@ final class DiffServiceTest extends TestCase
         self::assertStringContainsString(
             'Unsafe lock entry',
             $out->stderrBuffer,
-            "'validateDestination' must catch the traversal destination and emit the 'Unsafe lock entry' diagnostic; "
-            . 'removing the call to validateDestination would let the unsafe path through since validateSource has '
-            . 'nothing to reject for a safe source.',
+            "'validateDestination' must catch the traversal destination and emit the 'Unsafe lock entry' diagnostic.",
         );
     }
 
     public function testRunReturnsUnsafeSourceErrorEvenWhenDestinationIsSafe(): void
     {
-        /*
-         * Seed a fully valid provider tree with a safe destination but an unsafe source '../escape.php' so
-         * 'validateDestination' passes unconditionally. Removing the 'validateSource' call would let the unsafe source
-         * slip past without emitting the 'Unsafe lock entry' diagnostic.
-         */
+        // Safe destination + unsafe source so 'validateDestination' passes; isolates the 'validateSource' guard.
         $providerRoot = "{$this->tempDir}/vendor/pkg/name";
 
         $this->ensureTestDirectory($providerRoot);
@@ -610,9 +590,7 @@ final class DiffServiceTest extends TestCase
         self::assertStringContainsString(
             'Unsafe lock entry',
             $out->stderrBuffer,
-            "'validateSource' must catch the traversal source and emit the 'Unsafe lock entry' diagnostic; removing "
-            . 'the call to validateSource would let the unsafe source through since validateDestination has nothing '
-            . 'to reject for a safe destination.',
+            "'validateSource' must catch the traversal source and emit the 'Unsafe lock entry' diagnostic.",
         );
     }
 

--- a/tests/unit/Services/ProvidersServiceTest.php
+++ b/tests/unit/Services/ProvidersServiceTest.php
@@ -85,8 +85,7 @@ final class ProvidersServiceTest extends TestCase
         self::assertSame(
             ['pkg/with-files' => 1, 'pkg/zero-files' => 0],
             (new ProvidersService())->getProviders($this->tempDir),
-            "Providers recorded in the lock's top-level metadata must appear with a count of '0' when they have "
-            . 'no tracked files.',
+            "Providers recorded in the lock's top-level metadata must appear with count '0' when they have no files.",
         );
     }
 
@@ -134,15 +133,12 @@ final class ProvidersServiceTest extends TestCase
         self::assertStringNotContainsString(
             'Files',
             $out->stdoutBuffer,
-            "When the providers map is empty, the service must 'return' immediately and must not fall through to "
-            . "render the 'Provider Files' header; removing the early return would leak the header row below the "
-            . 'empty-state diagnostic.',
+            "When the providers map is empty, the service must 'return' before rendering the 'Provider Files' header.",
         );
         self::assertStringNotContainsString(
             str_repeat('-', 52),
             $out->stdoutBuffer,
-            'When the providers map is empty, the service must return before rendering the 52-dash separator; '
-            . 'leaking it proves the early return branch was bypassed.',
+            'When the providers map is empty, the service must return before rendering the 52-dash separator.',
         );
     }
 
@@ -255,8 +251,7 @@ final class ProvidersServiceTest extends TestCase
         self::assertStringContainsString(
             'pkg/a' . str_repeat(' ', 44 - strlen('pkg/a')) . ' 1' . PHP_EOL,
             $out->stdoutBuffer,
-            'The provider row must be followed by exactly one PHP_EOL; the provider name must be left-padded to the '
-            . '44-character column width.',
+            'The provider row must end with one PHP_EOL; the provider name must be left-padded to 44 chars.',
         );
     }
 

--- a/tests/unit/Services/ReapplyServiceTest.php
+++ b/tests/unit/Services/ReapplyServiceTest.php
@@ -47,8 +47,7 @@ final class ReapplyServiceTest extends TestCase
                 'cannot be safely reapplied',
                 $out->stdoutBuffer,
                 sprintf(
-                    "When a file is in '%s' mode, it cannot be safely reapplied (the message must be emitted for "
-                    . 'both append and prepend, not just one).',
+                    "When a file is in '%s' mode, it cannot be safely reapplied (message must emit for append and prepend).",
                     $mode,
                 ),
             );
@@ -56,8 +55,7 @@ final class ReapplyServiceTest extends TestCase
                 sprintf('mode "%s"', $mode),
                 $out->stdoutBuffer,
                 sprintf(
-                    "The diagnostic must name the actual mode ('%s') so users know which file-mapping entry "
-                    . 'triggered the skip.',
+                    "The diagnostic must name the actual mode ('%s') so users know which file-mapping entry skipped.",
                     $mode,
                 ),
             );
@@ -97,11 +95,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testAppendPrependModeSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Seed an append entry first (cannot be reapplied) followed by a replace entry (reapplicable). The first
-         * triggers the 'cannot be safely reapplied' continue-branch; the second must still be reapplied to verify the
-         * loop continues rather than breaks.
-         */
+        // Append entry first (skipped) then replace entry: the skip must 'continue' so the replace entry is reapplied.
         $this->seedTracked('.env.dist', "A=1\n", "A=1\n", mode: 'append');
         $this->seedTracked('config/params.php', "stub\n", "stub\n", mode: 'replace');
 
@@ -123,8 +117,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "config/params.php"',
             $out->stdoutBuffer,
-            "After the append skip, the foreach must 'continue' to the next entry; replacing 'continue' with 'break' "
-            . "would leave 'config/params.php' unprocessed.",
+            "After the append skip, the foreach must 'continue' to the next entry, not 'break'.",
         );
     }
 
@@ -214,11 +207,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testEnsureDirectoryFailureSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Entry 1 lives under a deep nested destination whose parent directory is removed before the run so
-         * 'is_dir' naturally returns false and 'mkdir' (mocked to fail) is actually reached. Entry 2 at the top
-         * level is reapplied normally, proving the loop continues past the ensureDirectory skip.
-         */
+        // Entry 1 is deep-nested with its parent removed so the mocked 'mkdir' is reached; entry 2 must still be reapplied.
         $this->seedTracked('deep/config/params.php', "stub\n", "stub\n");
         $this->seedTracked('top.txt', "stub\n", "stub\n");
 
@@ -354,11 +343,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testHashFailureSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Seed two entries with existing destinations; mock 'hash_file' to fail only for the first destination's
-         * path so the 'Could not hash "first..."' continue-branch fires. The second entry's hash succeeds and the
-         * file (unchanged) gets reapplied, proving the loop kept iterating after the first skip.
-         */
+        // Mock 'hash_file' to fail only on 'first.txt' so the continue-branch fires; 'second.txt' must still be reapplied.
         $this->seedTracked('first.txt', "stub\n", "stub\n");
         $this->seedTracked('second.txt', "stub\n", "stub\n");
 
@@ -388,8 +373,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "second.txt"',
             $out->stdoutBuffer,
-            "After the 'Could not hash' skip, the foreach must 'continue' so 'second.txt' is still reapplied; "
-            . "replacing 'continue' with 'break' aborts the scan prematurely.",
+            "After the 'Could not hash' skip, the foreach must 'continue' so 'second.txt' is still reapplied.",
         );
     }
 
@@ -441,8 +425,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "second.txt"',
             $out->stdoutBuffer,
-            "After 'Stub not found' the foreach must 'continue' to the next entry; replacing 'continue' with 'break' "
-            . "stops iteration before 'second.txt' can be reapplied.",
+            "After 'Stub not found' the foreach must 'continue' so 'second.txt' can still be reapplied.",
         );
     }
 
@@ -479,11 +462,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testPostWriteHashFailureSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Mock 'hash_file' to fail for both entries. Each reapply writes the stub but then fails on the
-         * post-write hash; each iteration emits its own 'Could not hash written file' diagnostic naming the
-         * specific destination. That proves the loop kept iterating after the first post-write hash failure.
-         */
+        // 'hash_file' fails for both entries so each reapply emits its own diagnostic, proving the loop keeps iterating.
         $this->seedTracked('first.txt', "new-stub\n", "user-edited\n", lockHashOf: "user-edited\n");
         $this->seedTracked('second.txt', "new-stub\n", "user-edited\n", lockHashOf: "user-edited\n");
 
@@ -513,17 +492,13 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'second.txt',
             $out->stderrBuffer,
-            "After the first post-write hash failure, the foreach must 'continue' so the second entry is processed "
-            . "and emits its own diagnostic naming 'second.txt'; replacing 'continue' with 'break' would silence it.",
+            "After the first post-write hash failure, the foreach must 'continue' so 'second.txt' emits its own diagnostic.",
         );
     }
 
     public function testPostWriteHashFailureSkipsLockUpdate(): void
     {
-        /*+
-         * Seed divergent stub vs current content with a known lock hash so that a successful run would update the hash
-         * to 'sha256(stub)'; the failure path must leave the original hash untouched.
-         */
+        // Divergent stub vs current content so the success path would update the hash; the failure path must leave it.
         $this->seedTracked(
             'config/params.php',
             stubContent: "new-stub\n",
@@ -564,8 +539,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertSame(
             $originalLockHash,
             (new LockFile($this->tempDir))->read()['files']['config/params.php']['hash'] ?? null,
-            'Post-condition: when the post-write hash throws, the lock entry must stay frozen at the pre-run hash '
-            . '(skip-the-lock-update branch exercised).',
+            'When the post-write hash throws, the lock entry must stay frozen at the pre-run hash.',
         );
     }
 
@@ -655,10 +629,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testPreserveSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Entry 1: preserve-mode file already on disk triggers the 'use --force to overwrite' skip-continue.
-         * Entry 2: replace-mode file that must still be reapplied.
-         */
+        // Entry 1 (preserve) triggers the skip-continue; entry 2 (replace) must still be reapplied.
         $this->seedTracked('config/web.php', "stub\n", "current\n", mode: 'preserve', lockHashOf: "stub\n");
         $this->seedTracked('config/params.php', "stub\n", "stub\n", mode: 'replace');
 
@@ -680,8 +651,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "config/params.php"',
             $out->stdoutBuffer,
-            "After the preserve skip, the foreach must 'continue' so the next replace-mode entry is reapplied; "
-            . "replacing 'continue' with 'break' aborts the scan prematurely.",
+            "After the preserve skip, the foreach must 'continue' so the next replace-mode entry is reapplied.",
         );
     }
 
@@ -714,11 +684,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testProviderFilterSkipOnFirstEntryContinuesIterationToNextMatchingEntry(): void
     {
-        /*
-         * Seed non-matching entry first so the provider-filter guard triggers 'continue'; the second entry matches
-         * and must still be processed. Replacing 'continue' with 'break' would abort the loop before the matching
-         * entry is reached.
-         */
+        // Non-matching entry first so the provider-filter guard 'continues'; the matching entry must still be processed.
         $this->seedTracked('non-match.txt', "x\n", "x\n", provider: 'pkg/other');
         $this->seedTracked('match.txt', "y\n", "y\n", provider: 'pkg/target');
 
@@ -735,8 +701,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "match.txt"',
             $out->stdoutBuffer,
-            "After the provider-filter guard rejects a non-matching entry, the foreach must 'continue' to the next "
-            . "entry; replacing 'continue' with 'break' would stop iteration and fail to process 'match.txt'.",
+            "After the provider-filter guard rejects an entry, the foreach must 'continue' so 'match.txt' is processed.",
         );
     }
 
@@ -803,9 +768,7 @@ final class ReapplyServiceTest extends TestCase
             self::assertSame(
                 0755,
                 fileperms($destination) & 0777,
-                "After 'ReapplyService' rewrites the stub content, it must invoke 'syncPermissions' so the destination "
-                . "inherits the source executable bit (0755 here); without 'syncPermissions' the file would keep the "
-                . "umask-derived 0644 that 'file_put_contents' produces, breaking re-scaffolded CLI stubs like 'yii'.",
+                "After 'ReapplyService' rewrites the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {
             umask($oldUmask);
@@ -852,10 +815,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testRejectsLockEntryWithUnsafeSourceEvenWhenDestinationIsSafe(): void
     {
-        /*
-         * Seed two lock entries where destination is safe but source carries path traversal; removing the
-         * 'validateSource' call in the try block would let the unsafe source through.
-         */
+        // Safe destination + unsafe source isolates the 'validateSource' guard inside the try block.
         $providerRoot = "{$this->tempDir}/vendor/pkg/name";
 
         $this->ensureTestDirectory($providerRoot);
@@ -892,9 +852,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Unsafe lock entry',
             $out->stderrBuffer,
-            "'validateSource' must catch the traversal source and emit the 'Unsafe lock entry' diagnostic; removing "
-            . "the 'validateSource' call would let the unsafe source through since 'validateDestination' has nothing "
-            . 'to reject for a safe destination.',
+            "'validateSource' must catch the traversal source and emit the 'Unsafe lock entry' diagnostic.",
         );
     }
 
@@ -915,9 +873,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertSame(
             1,
             $exitCode,
-            'When both filters are set and nothing matches, the service must emit an error exit code; the guard is '
-            . "'(file !== '' || provider !== '') && !anyMatched' and must short-circuit correctly even when both "
-            . 'filters are non-empty.',
+            'When both filters are set and nothing matches, the service must emit an error exit code.',
         );
         self::assertStringContainsString(
             'No tracked files matched',
@@ -969,14 +925,12 @@ final class ReapplyServiceTest extends TestCase
         self::assertSame(
             0,
             $exitCode,
-            "When no filter is supplied, running against an empty lock must be a silent no-op; the 'no match' error is "
-            . "gated by 'file !== '' || provider !== ''' and must not fire when both filters are empty.",
+            "When no filter is supplied, running against an empty lock must be a silent no-op (no 'no match' error).",
         );
         self::assertStringNotContainsString(
             'No tracked files matched',
             $out->stderrBuffer,
-            'Without any filter, the no-match diagnostic must stay silent; emitting it would confuse users who ran '
-            . "'reapply' on a fresh project.",
+            "Without any filter, the no-match diagnostic must stay silent for users running 'reapply' on a fresh project.",
         );
     }
 
@@ -1069,11 +1023,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testStubReadFailureSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Seed two entries; mock 'file_get_contents' to fail so both attempts return `false`. The first triggers
-         * the 'Could not read stub' continue-branch; the second would also fail, but the test asserts that the
-         * second diagnostic IS emitted, proving the loop kept iterating after the first skip.
-         */
+        // Two entries with 'file_get_contents' mocked to fail; both must emit their own diagnostic, proving loop iteration.
         $this->seedTracked('first.txt', "stub\n", "stub\n");
         $this->seedTracked('second.txt', "stub\n", "stub\n");
 
@@ -1103,18 +1053,13 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'second.txt',
             $out->stderrBuffer,
-            "After the first stub-read failure, the foreach must 'continue' so the second entry is processed and "
-            . "emits its own diagnostic naming 'second.txt'; replacing 'continue' with 'break' would silence it.",
+            "After the first stub-read failure, the foreach must 'continue' so 'second.txt' emits its own diagnostic.",
         );
     }
 
     public function testSuccessfulReapplyUpdatesLockHashAndPreservesProvidersKey(): void
     {
-        /*
-         * Seed divergent stub vs current content with a lock hash pinned to the current content so a successful
-         * force-reapply must flip the lock hash to 'sha256(stub)' and the write call must also carry the 'providers'
-         * key untouched.
-         */
+        // Divergent stub vs current content so a force-reapply must flip the lock hash to 'sha256(stub)'.
         $this->seedTracked(
             'config/params.php',
             stubContent: "new-stub\n",
@@ -1151,14 +1096,12 @@ final class ReapplyServiceTest extends TestCase
         self::assertSame(
             $expectedHash,
             $data['files']['config/params.php']['hash'],
-            'After a successful reapply the lock hash must reflect the newly written stub contents; the write '
-            . 'branch must run (not be negated) and must carry the new hash.',
+            'After a successful reapply the lock hash must reflect the newly written stub contents.',
         );
         self::assertArrayHasKey(
             'pkg/name',
             $data['providers'],
-            "The 'providers' key must survive the lock rewrite; dropping it on write would lose top-level provider "
-            . 'metadata that downstream commands rely on for path resolution.',
+            "The 'providers' key must survive the lock rewrite; top-level provider metadata is required downstream.",
         );
 
         $providerEntry = $data['providers']['pkg/name'] ?? null;
@@ -1176,11 +1119,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testUnsafeLockEntrySkipContinuesIterationToNextFile(): void
     {
-        /*
-         * Seed two entries: the first has an unsafe destination ('../escape.php') that triggers the validator's
-         * skip-and-continue branch; the second must still be reapplied, proving the loop 'continues' rather than
-         * 'breaks'.
-         */
+        // First entry has an unsafe destination that triggers skip-continue; the second must still be reapplied.
         $unsafeDestination = '../escape.php';
         $validDestination = 'config/params.php';
 
@@ -1237,17 +1176,13 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "config/params.php"',
             $out->stdoutBuffer,
-            'After the unsafe entry triggers the skip branch, the foreach must keep iterating so the second (valid) '
-            . "entry is still reapplied; replacing 'continue' with 'break' would stop the loop and fail this check.",
+            'After the unsafe entry triggers the skip branch, the foreach must keep iterating to reapply the valid entry.',
         );
     }
 
     public function testUserModifiedSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Entry 1: non-force, user-modified file triggers the 'is user-modified' skip-continue.
-         * Entry 2: replace-mode in sync file that must still be reapplied.
-         */
+        // Entry 1 (user-modified) triggers skip-continue; entry 2 (in-sync replace) must still be reapplied.
         $this->seedTracked('config/params.php', "stub\n", "user-edited\n", lockHashOf: "stub\n");
         $this->seedTracked('config/web.php', "stub\n", "stub\n");
 
@@ -1269,8 +1204,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'Reapplied "config/web.php"',
             $out->stdoutBuffer,
-            "After 'is user-modified' the foreach must 'continue' so the next in-sync entry is reapplied; replacing "
-            . "'continue' with 'break' aborts the scan prematurely.",
+            "After 'is user-modified' the foreach must 'continue' so the next in-sync entry is reapplied.",
         );
     }
 
@@ -1304,10 +1238,7 @@ final class ReapplyServiceTest extends TestCase
 
     public function testWriteFailureSkipContinuesIterationToNextReapplicableEntry(): void
     {
-        /*
-         * Mock 'file_put_contents' to fail for both entries. Each iteration must emit its own 'Could not write'
-         * diagnostic naming the specific path; that proves the loop kept iterating after the first write failure.
-         */
+        // Mock 'file_put_contents' to fail for both entries; each must emit its own diagnostic, proving loop iteration.
         $this->seedTracked('first.txt', "stub\n", "stub\n");
         $this->seedTracked('second.txt', "stub\n", "stub\n");
 
@@ -1337,8 +1268,7 @@ final class ReapplyServiceTest extends TestCase
         self::assertStringContainsString(
             'second.txt',
             $out->stderrBuffer,
-            "After the first write failure, the foreach must 'continue' so the second entry is processed; replacing "
-            . "'continue' with 'break' would silence the second diagnostic.",
+            "After the first write failure, the foreach must 'continue' so the second entry still emits a diagnostic.",
         );
     }
 

--- a/tests/unit/Services/StatusServiceTest.php
+++ b/tests/unit/Services/StatusServiceTest.php
@@ -62,8 +62,7 @@ final class StatusServiceTest extends TestCase
         self::assertArrayHasKey(
             'valid.txt',
             $statuses,
-            "When an earlier entry triggers the unsafe-destination branch, the foreach must continue, not 'break'; "
-            . 'the second valid entry must still be reported.',
+            "An earlier unsafe-destination entry must not 'break' the foreach; the next valid entry must still report.",
         );
         self::assertSame(
             'synced',
@@ -167,8 +166,7 @@ final class StatusServiceTest extends TestCase
         self::assertCount(
             2,
             $statuses,
-            "The status map must contain every tracked entry verbatim; a silent 'array_slice' of the first element "
-            . 'would drop the second row and mislead the CLI.',
+            'The status map must contain every tracked entry; dropping rows would mislead the CLI.',
         );
         self::assertArrayHasKey(
             'second.txt',
@@ -331,12 +329,7 @@ final class StatusServiceTest extends TestCase
 
     public function testRunPinsColStatusToLiteralSixWhenObservedStatusIsShorter(): void
     {
-        /*
-         * Seed an unsafe destination so 'getStatuses' returns status='error' (length 5), which is strictly shorter
-         * than the literal '6' used in 'max(6, ...)'. Combined with short destination, provider and mode fields this
-         * makes the separator width entirely dependent on the colStatus literal; decrementing it to '5' shrinks the
-         * separator by one dash, which the assertion below detects.
-         */
+        // 'getStatuses' returns status='error' (length 5); separator width therefore depends on the 'max(6,...)' literal.
         (new LockFile($this->tempDir))->write(
             [
                 'providers' => [],
@@ -461,11 +454,7 @@ final class StatusServiceTest extends TestCase
 
         $hash = (new Hasher())->hash($filePath);
 
-        /*
-         * Seed every field with a value shorter than the literal column widths (4/8/4/6 plus `6` padding) so the
-         * rendered separator row is driven solely by those literals; this is what pins down the mutations that
-         * increment/decrement any of them.
-         */
+        // All fields shorter than the column literals (4/8/4/6) so the separator width depends solely on those literals.
         (new LockFile($this->tempDir))->write(
             [
                 'providers' => [],


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
