### PR TITLE
feat!: make `AppendMode` idempotent: append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - test: kill remaining path-normalization mutants and keep Infection MSI at `100%`.
 - feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.
 - test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.
+- feat!: make `AppendMode` idempotent append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - test: kill remaining path-normalization mutants and keep Infection MSI at `100%`.
 - feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.
 - test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.
-- feat!: make `AppendMode` idempotent append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.
+- feat!: make `AppendMode` idempotent: append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         "composer-plugin-api": "^2.3",
         "composer/composer": "^2.9",
         "sebastian/diff": "^7.0",
-        "symfony/console": "^7.0"
+        "symfony/console": "^7.4"
     },
     "bin": [
         "bin/scaffold"
     ],
     "require-dev": {
-        "composer/composer": "^2.7",
+        "composer/composer": "^2.9",
         "infection/infection": "^0.32",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/coding-standard": "^0.1",
+        "php-forge/coding-standard": "^0.2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,7 @@ Versions come from Composer's `getPrettyVersion()`.
 
 ## Next steps
 
+- 📖 [Readme](../README.md)
 - 📦 [Creating Providers](providers.md)
 - 🔀 [File Modes](modes.md)
 - 🖥️ [Console Commands](console.md)

--- a/docs/console.md
+++ b/docs/console.md
@@ -131,3 +131,11 @@ All commands follow standard Symfony Console conventions:
 
 Use the exit code in CI scripts to halt on failures (for example, `vendor/bin/scaffold status` always returns `0`
 regardless of `modified` / `missing` entries; inspect the text output yourself if you want CI to gate on drift).
+
+## Next steps
+
+- 📖 [Readme](../README.md)
+- 🔀 [File Modes](modes.md)
+- ⚙️ [Configuration Reference](configuration.md)
+- 📦 [Creating Providers](providers.md)
+- 🧪 [Testing Guide](testing.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,7 @@ No framework bootstrap is required; the binary starts directly from Composer's a
 
 ## Next steps
 
+- 📖 [Readme](../README.md)
 - ⚙️ [Configuration Reference](configuration.md)
 - 📦 [Creating Providers](providers.md)
 - 🔀 [File Modes](modes.md)

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -6,12 +6,12 @@ when a file has been modified by the developer after scaffolding.
 
 ## Mode reference
 
-| Mode       | File absent                | File present (unmodified)                                                                                                                             | File present (user-modified)                              |
-| ---------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| `replace`  | Writes stub, records hash. | Overwrites with stub, updates hash.                                                                                                                   | **Skips** — emits warning to stderr.                      |
-| `preserve` | Writes stub, records hash. | **Skips**; never overwrites.                                                                                                                          | **Skips**; never overwrites.                              |
-| `append`   | Writes stub, records hash. | Appends stub content (`FILE_APPEND`), updates hash (full scaffold only; skipped on `post-install-cmd`/`post-update-cmd` if already in lock).          | Appends stub content, updates hash (full scaffold only).  |
-| `prepend`  | Writes stub, records hash. | Prepends stub content before existing content, updates hash (full scaffold only; skipped on `post-install-cmd`/`post-update-cmd` if already in lock). | Prepends stub content, updates hash (full scaffold only). |
+| Mode       | File absent                | File present (unmodified)                                                                                                                                     | File present (user-modified)                                                                          |
+| ---------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `replace`  | Writes stub, records hash. | Overwrites with stub, updates hash.                                                                                                                           | **Skips** emits warning to stderr.                                                                    |
+| `preserve` | Writes stub, records hash. | **Skips**; never overwrites.                                                                                                                                  | **Skips**; never overwrites.                                                                          |
+| `append`   | Writes stub, records hash. | Appends only stub lines not already present in the file (idempotent line merge); updates hash. Returns `Skipped` when every stub line is already in the file. | Appends only stub lines not already present in the file (idempotent line merge); user lines are kept. |
+| `prepend`  | Writes stub, records hash. | Prepends stub content before existing content, updates hash (full scaffold only; skipped on `post-install-cmd`/`post-update-cmd` if already in lock).         | Prepends stub content, updates hash (full scaffold only).                                             |
 
 ## Hash tracking
 
@@ -23,9 +23,11 @@ On subsequent runs the plugin compares the current on-disk hash to the recorded 
 - **Hashes differ**; the developer has modified the file. For `replace`, the plugin skips the file and writes a warning
   to stderr. For `preserve`, the file is always skipped regardless of hash.
 
-`append` and `prepend` do not compare hashes; they always add content. On partial scaffold runs (`post-install-cmd`,
-`post-update-cmd`) these modes are skipped for files already recorded in the lockfile, preventing duplicate content on
-repeated `composer install` calls.
+`append` does not compare hashes; instead it diffs the stub lines against the destination and writes only the missing
+ones. The operation is therefore idempotent repeated runs over a file that already contains every stub line are a no-op.
+On partial scaffold runs (`post-install-cmd`, `post-update-cmd`), `append` and `prepend` are also skipped at the
+scaffolder level for files already recorded in the lockfile as a performance optimisation; the line-diff guarantees
+correctness even without that skip.
 
 ## replace
 
@@ -53,9 +55,17 @@ Once written, the file is never touched again by the scaffold process.
 
 ## append
 
-Appends the stub content to the end of the destination file on every full scaffold run.
-Useful for adding entries to `.gitignore`, environment variable lists, or configuration arrays
-where concatenation is safe.
+Idempotent line merge. The plugin reads both the stub and the destination, splits each on `\n` (after trimming the
+trailing newline), and appends only the stub lines that are not already present in the destination. Repeated runs over
+a destination that already contains every stub line are a no-op (`ApplyOutcome::Skipped`); developer-added lines are
+never removed.
+
+Use it for line-based, comment-tolerant files where the destination may already contain the stub content (because the
+project follows the same baseline) or where the developer routinely adds project-specific entries:
+
+- `.gitignore`, `.gitattributes`, `.editorconfig`
+- `.prettierignore`, `.stylelintignore`
+- Environment variable lists, plain-text allowlists
 
 ```json
 ".gitignore": {
@@ -63,6 +73,9 @@ where concatenation is safe.
     "mode": "append"
 }
 ```
+
+> **Note:** `append` operates at the line level. It is not safe for structured documents (JSON, YAML, TOML, XML); use
+> `replace` or `preserve` for those.
 
 ## prepend
 
@@ -89,5 +102,6 @@ This overwrites the file, computes the new hash, and updates `scaffold-lock.json
 
 ## Next steps
 
+- 📖 [Readme](../README.md)
 - 🖥️ [Console Commands](console.md)
 - ⚙️ [Configuration Reference](configuration.md)

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -24,7 +24,7 @@ On subsequent runs the plugin compares the current on-disk hash to the recorded 
   to stderr. For `preserve`, the file is always skipped regardless of hash.
 
 `append` does not compare hashes; instead it diffs the stub lines against the destination and writes only the missing
-ones. The operation is therefore idempotent repeated runs over a file that already contains every stub line are a no-op.
+ones. The operation is therefore idempotent: repeated runs over a file that already contains every stub line are a no-op.
 On partial scaffold runs (`post-install-cmd`, `post-update-cmd`), `append` and `prepend` are also skipped at the
 scaffolder level for files already recorded in the lockfile as a performance optimisation; the line-diff guarantees
 correctness even without that skip.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,11 +10,11 @@ root project's `allowed-packages` list.
 
 Every provider declares a `scaffold` manifest with three keys:
 
-- `copy` (required, array of paths) — directories or files relative to the provider root. Directories are walked
+- `copy` (required, array of paths) directories or files relative to the provider root. Directories are walked
   recursively.
-- `exclude` (optional, array of glob patterns) — patterns omitted from the walk. Only applies to directory entries in
+- `exclude` (optional, array of glob patterns) patterns omitted from the walk. Only applies to directory entries in
   `copy`; explicit file entries bypass this filter.
-- `modes` (optional, map of glob pattern → [file mode](modes.md)) — overrides the default write mode per destination.
+- `modes` (optional, map of glob pattern → [file mode](modes.md)) overrides the default write mode per destination.
   Exact path matches win over glob matches; the default when no pattern matches is `replace`.
 
 ## Inline manifest
@@ -102,12 +102,12 @@ Patterns in `exclude` and the keys of `modes` support:
 
 ## File modes
 
-| Mode       | Behaviour                                                                                            |
-| ---------- | ---------------------------------------------------------------------------------------------------- |
-| `replace`  | Writes the stub. Skips if the destination has been modified by the user since the last scaffold run. |
-| `preserve` | Writes the stub only if the destination does not already exist on disk. Never overwrites.            |
-| `append`   | Appends the stub content to the destination. Creates the file if absent.                             |
-| `prepend`  | Prepends the stub content before existing destination content. Creates the file if absent.           |
+| Mode       | Behaviour                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| `replace`  | Writes the stub. Skips if the destination has been modified by the user since the last scaffold run.                |
+| `preserve` | Writes the stub only if the destination does not already exist on disk. Never overwrites.                           |
+| `append`   | Appends only stub lines not already present in the destination (idempotent line merge). Creates the file if absent. |
+| `prepend`  | Prepends the stub content before existing destination content. Creates the file if absent.                          |
 
 See [File Modes](modes.md) for a detailed description of each mode and the hash-tracking mechanism.
 
@@ -134,7 +134,7 @@ can list the exact path as an explicit file entry in `copy`; explicit file entri
 
 ## Provider layout
 
-Because `copy` walks the provider tree directly, providers look like real Yii2 apps — there is no `stubs/` wrapper and
+Because `copy` walks the provider tree directly, providers look like real Yii2 apps there is no `stubs/` wrapper and
 no per-file declaration:
 
 ```text
@@ -171,5 +171,6 @@ The plugin validates every entry before writing:
 
 ## Next steps
 
+- 📖 [Readme](../README.md)
 - 🔀 [File Modes](modes.md)
 - 🖥️ [Console Commands](console.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -134,7 +134,7 @@ can list the exact path as an explicit file entry in `copy`; explicit file entri
 
 ## Provider layout
 
-Because `copy` walks the provider tree directly, providers look like real Yii2 apps there is no `stubs/` wrapper and
+Because `copy` walks the provider tree directly, providers look like real Yii2 apps. There is no `stubs/` wrapper and
 no per-file declaration:
 
 ```text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,131 +1,90 @@
-# Testing guide
+# Testing
 
-This document describes how the test suite is organized, how to run specific subsets, and how to add new fixtures or
-tests when contributing.
+This package provides a consistent set of [Composer](https://getcomposer.org/) scripts for local validation.
 
-## Suite layout
+Tool references:
 
-```text
-tests/
-├── unit/                  # pure, fast unit tests per src/ namespace
-│   ├── Commands/          # console controllers via spies (no real stdout writes)
-│   ├── Manifest/
-│   ├── Modes/
-│   ├── Scaffold/
-│   │   └── Lock/
-│   └── Security/
-├── functional/            # real Composer instance, event-driven, temporary project
-├── support/               # shared helpers, spies, traits
-│   └── Spies/             # Controller subclasses that buffer stdout/stderr
-└── fixtures/              # static manifests / invalid payloads used as read-only inputs
-    └── providers/
-```
+- [Composer Require Checker](https://github.com/maglnet/ComposerRequireChecker) for dependency definition checks.
+- [Easy Coding Standard (ECS)](https://github.com/easy-coding-standard/easy-coding-standard) for coding standards.
+- [Infection](https://infection.github.io/) for mutation testing.
+- [PHPStan](https://phpstan.org/) for static analysis.
+- [PHPUnit](https://phpunit.de/) for unit tests.
+- [Rector](https://github.com/rectorphp/rector) for automated refactoring.
 
-The `unit` and `functional` groups are reflected in PHPUnit `#[Group]` attributes. Every test also belongs to the
-`scaffold` meta-group.
+## Automated refactoring (Rector)
 
-## Running the suite
+Run Rector to apply automated code refactoring.
 
 ```bash
-vendor/bin/phpunit                              # full suite, quiet
-vendor/bin/phpunit --group commands             # only console-controller tests
-vendor/bin/phpunit --group functional           # only Composer-driven end-to-end tests
-vendor/bin/phpunit --filter MultiLayer          # substring filter on test class name
+composer rector
 ```
 
-## Unit tests
+## Coding standards (ECS)
 
-Unit tests exercise a single class in isolation. Controller tests use **spies** under `tests/support/Spies/` because
-Yii's console `Controller::stdout()` writes directly to the `STDOUT` stream, which bypasses PHPUnit's output capture.
-Each spy extends its production controller and overrides `stdout()`/`stderr()` so tests can assert on buffered output.
-
-```php
-final class ProvidersControllerTest extends TestCase
-{
-    public function testExample(): void
-    {
-        $controller = new ProvidersControllerSpy('providers', $module);
-        $controller->actionIndex();
-
-        self::assertStringContainsString('pkg/name', $controller->stdoutBuffer);
-    }
-}
-```
-
-Production controllers are declared without `final` precisely to support these spies.
-
-## Functional tests
-
-Functional tests spin up a **real `Composer\Composer` instance** against a fake project generated in a temporary
-directory, seed its local repository with mock provider packages, and dispatch the same script events the plugin
-subscribes to in production. They exercise the entire chain
-
-```text
-Script event → EventSubscriber → Scaffolder → modes → lock file
-```
-
-without the cost or flakiness of a full `composer install`.
-
-The `ComposerEventHarness` trait at `tests/support/ComposerEventHarness.php` centralizes the boilerplate:
-
-```php
-final class MyTest extends TestCase
-{
-    use ComposerEventHarness;
-    use TempDirectoryTrait;
-
-    public function testExample(): void
-    {
-        $builder = new FakeProjectBuilder($this->tempDir);
-        $builder->createStubFile('demo/scaffold', 'stubs/config/app.php', "<?php\n");
-        $builder->createComposerJson([
-            'name' => 'demo/smoke-project',
-            'config' => ['vendor-dir' => $builder->getVendorDir()],
-            'extra' => ['scaffold' => ['allowed-packages' => ['demo/scaffold']]],
-        ]);
-
-        $io = new BufferIO();
-        $composer = $this->buildComposerForProject($builder->getProjectRoot(), $io);
-        $this->addMockProvider($composer, 'demo/scaffold', [
-            'file-mapping' => [
-                'config/app.php' => ['source' => 'stubs/config/app.php', 'mode' => 'replace'],
-            ],
-        ]);
-        $this->resetInstallScaffoldRanFlag();
-
-        (new EventSubscriber())->onPostInstall($this->makePostInstallEvent($composer, $io));
-
-        self::assertFileExists($builder->getProjectRoot() . '/config/app.php');
-    }
-}
-```
-
-`resetInstallScaffoldRanFlag()` clears the process-wide static flag in `EventSubscriber`, which is required when a
-single test dispatches multiple lifecycle events.
-
-## Fixtures
-
-Static fixtures under `tests/fixtures/providers/` are read-only sample provider packages used by manifest-loader and
-security tests. Keep them minimal: anything that needs a composer.json on disk belongs in a fixture; anything that can
-be built at runtime belongs in `FakeProjectBuilder`.
-
-## Adding a new test
-
-- **Testing a pure class?** Add a unit test mirroring the `src/` path.
-- **Testing a console controller?** Use or create a spy under `tests/support/Spies/`.
-- **Testing an event handler or multi-provider scenario?** Use `ComposerEventHarness` and dispatch
-  the real script event; do not call `Scaffolder::scaffold()` directly.
-- **Introducing a new persistent input?** Prefer `FakeProjectBuilder`/`FakeProjectBuilder::createComposerJson`
-  over static fixtures when the file only matters for one test.
-
-## Static analysis and style
+Run Easy Coding Standard (ECS) and apply fixes.
 
 ```bash
-vendor/bin/phpstan analyse                      # level max, zero tolerance
-vendor/bin/ecs check                            # PER-3 + PSR-12 + PHP-CS-Fixer
-vendor/bin/ecs check --fix                      # auto-fix style violations
-vendor/bin/infection                            # mutation testing
+composer ecs
 ```
 
-Failing static analysis is always a blocker. Do not suppress PHPStan errors with `@phpstan-ignore`; fix the underlying
-cause or narrow the type.
+## Dependency definition check
+
+Verify that runtime dependencies are correctly declared in `composer.json`.
+
+```bash
+composer check-dependencies
+```
+
+## Mutation testing (Infection)
+
+Run mutation testing.
+
+```bash
+composer mutation
+```
+
+Run mutation testing with static analysis enabled.
+
+```bash
+composer mutation-static
+```
+
+## Static analysis (PHPStan)
+
+Run static analysis.
+
+```bash
+composer static
+```
+
+## Unit tests (PHPUnit)
+
+Run the full test suite.
+
+```bash
+composer tests
+```
+
+## Passing extra arguments
+
+Composer scripts support forwarding additional arguments using `--`.
+
+Run PHPUnit with code coverage report generation.
+
+```bash
+composer tests -- --coverage-html code_coverage
+```
+
+Run PHPStan with a different memory limit.
+
+```bash
+composer static -- --memory-limit=512M
+```
+
+## Next steps
+
+- 📖 [Readme](../README.md)
+- 🔀 [File Modes](modes.md)
+- ⚙️ [Configuration Reference](configuration.md)
+- 📦 [Creating Providers](providers.md)
+- 🖥️ [Console Commands](console.md)

--- a/ecs.php
+++ b/ecs.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /** @var \Symplify\EasyCodingStandard\Configuration\ECSConfigBuilder $ecsConfigBuilder */
-$ecsConfigBuilder = require __DIR__ . '/vendor/php-forge/coding-standard/config/ecs.php';
+$ecsConfigBuilder = require __DIR__ . '/vendor/php-forge/coding-standard/src/ecs-83.php';
 
 return $ecsConfigBuilder->withPaths(
     [

--- a/rector.php
+++ b/rector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/vendor/php-forge/coding-standard/config/rector.php');
+    $rectorConfig->import(__DIR__ . '/vendor/php-forge/coding-standard/src/rector-83.php');
 
     $rectorConfig->paths(
         [

--- a/src/Console/SymfonyOutputWriter.php
+++ b/src/Console/SymfonyOutputWriter.php
@@ -20,9 +20,9 @@ use Symfony\Component\Console\Output\{ConsoleOutputInterface, OutputInterface};
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class SymfonyOutputWriter implements OutputWriter
+final readonly class SymfonyOutputWriter implements OutputWriter
 {
-    public function __construct(private readonly OutputInterface $output) {}
+    public function __construct(private OutputInterface $output) {}
 
     /**
      * Writes `$message` to stderr followed by a single trailing newline, bypassing Symfony's formatter.

--- a/src/Console/VendorDirResolver.php
+++ b/src/Console/VendorDirResolver.php
@@ -95,7 +95,7 @@ final class VendorDirResolver
             || preg_match('#^[A-Za-z]:[/\\\\]#', $path) === 1;
 
         if ($isAbsolute) {
-            // preserve drive-root separator: "C:\" and "C:/" must remain 3 characters.
+            // Preserve drive-root separator: "C:\" and "C:/" must remain 3 characters.
             if (preg_match('#^([A-Za-z]:)([/\\\\])$#', $path, $matches) === 1) {
                 return $matches[1] . $matches[2];
             }

--- a/src/Manifest/FileMapping.php
+++ b/src/Manifest/FileMapping.php
@@ -10,13 +10,13 @@ namespace yii\scaffold\Manifest;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class FileMapping
+final readonly class FileMapping
 {
     public function __construct(
-        public readonly string $destination,
-        public readonly string $source,
-        public readonly FileMode $mode,
-        public readonly string $providerName,
-        public readonly string $providerPath,
+        public string $destination,
+        public string $source,
+        public FileMode $mode,
+        public string $providerName,
+        public string $providerPath,
     ) {}
 }

--- a/src/Manifest/Glob.php
+++ b/src/Manifest/Glob.php
@@ -13,10 +13,10 @@ use function preg_replace_callback;
  *
  * Supports the subset used by `scaffold.json`:
  *
- * - `*` — any sequence of characters that does NOT include a path separator.
- * - `**` — any sequence, including path separators (matches across directories).
- * - `?` — a single character that is not a path separator.
- * - literals — everything else matches byte-exact.
+ * - `*` any sequence of characters that does NOT include a path separator.
+ * - `**` any sequence, including path separators (matches across directories).
+ * - `?` a single character that is not a path separator.
+ * - literals everything else matches byte-exact.
  *
  * Paths are normalised to forward slashes before matching so providers can share patterns across POSIX and Windows.
  *
@@ -52,7 +52,7 @@ final class Glob
         // @codeCoverageIgnoreStart
         $regex = (string) preg_replace_callback(
             '#\*\*/|\*\*|\*|\?|[^*?]+#',
-            static fn(array $match) => match ($match[0]) {
+            static fn(array $match): string => match ($match[0]) {
                 '**/' => '(?:.*/)?',
                 '**' => '.*',
                 '*' => '[^/]*',

--- a/src/Manifest/ManifestLoader.php
+++ b/src/Manifest/ManifestLoader.php
@@ -78,7 +78,7 @@ final readonly class ManifestLoader
             );
         }
 
-        // reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
+        // Reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
         $isAbsolute = str_starts_with($manifestPath, '/')
             || str_starts_with($manifestPath, '\\')
             || preg_match('/^[A-Za-z]:/', $manifestPath) === 1;

--- a/src/Manifest/ManifestLoader.php
+++ b/src/Manifest/ManifestLoader.php
@@ -26,9 +26,9 @@ use function str_starts_with;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class ManifestLoader
+final readonly class ManifestLoader
 {
-    public function __construct(private readonly ManifestSchema $schema, private readonly ManifestExpander $expander) {}
+    public function __construct(private ManifestSchema $schema, private ManifestExpander $expander) {}
 
     /**
      * Loads the provider's manifest and expands it into concrete file mappings.

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -68,7 +68,7 @@ final class ManifestSchema
             );
         }
 
-        // reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
+        // Reject absolute paths: POSIX ('/foo'), Windows UNC/backslash ('\foo'), Windows drive ('C:\foo').
         $isAbsolute = str_starts_with($path, '/')
             || str_starts_with($path, '\\')
             || preg_match('/^[A-Za-z]:/', $path) === 1;

--- a/src/Scaffold/Applier.php
+++ b/src/Scaffold/Applier.php
@@ -21,13 +21,13 @@ use function realpath;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class Applier
+final readonly class Applier
 {
     public function __construct(
-        private readonly PackageAllowlist $allowlist,
-        private readonly PathValidator $pathValidator,
-        private readonly Hasher $hasher,
-        private readonly IOInterface $io,
+        private PackageAllowlist $allowlist,
+        private PathValidator $pathValidator,
+        private Hasher $hasher,
+        private IOInterface $io,
     ) {}
 
     /**

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -56,7 +56,7 @@ final class AppendMode implements ModeInterface
         $consumerContent = file_get_contents($destination);
 
         if ($consumerContent === false) {
-            throw new RuntimeException(sprintf('Could not read source file "%s".', $destination));
+            throw new RuntimeException(sprintf('Could not read destination file "%s".', $destination));
         }
 
         $consumerLines = $consumerContent === '' ? [] : explode("\n", rtrim($consumerContent, "\n"));

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -14,6 +14,7 @@ use function explode;
 use function implode;
 use function preg_replace;
 use function sprintf;
+use function str_contains;
 use function str_ends_with;
 use function substr;
 
@@ -60,6 +61,10 @@ final class AppendMode implements ModeInterface
             throw new RuntimeException(sprintf('Could not read destination file "%s".', $destination));
         }
 
+        // Detect the destination EOL style BEFORE normalising so the appended block can be emitted in the same style,
+        // avoiding mixed CRLF/LF output on Windows-style files.
+        $eol = self::detectEol($consumerContent);
+
         // Normalise line endings so CRLF/CR destinations diff identically against an LF stub.
         $providerContent = (string) preg_replace('/\r\n|\r/', "\n", $providerContent);
         $consumerContent = (string) preg_replace('/\r\n|\r/', "\n", $consumerContent);
@@ -86,14 +91,38 @@ final class AppendMode implements ModeInterface
             return new ApplyResult(ApplyOutcome::Skipped, $hasher->hash($destination), null);
         }
 
-        $separator = $consumerContent === '' || str_ends_with($consumerContent, "\n") ? '' : "\n";
-        $appendData = $separator . implode("\n", $missing) . "\n";
+        $separator = $consumerContent === '' || str_ends_with($consumerContent, "\n") ? '' : $eol;
+        $appendData = $separator . implode($eol, $missing) . $eol;
 
         if (file_put_contents($destination, $appendData, FILE_APPEND) === false) {
             throw new RuntimeException(sprintf('Could not write to "%s".', $destination));
         }
 
         return new ApplyResult(ApplyOutcome::Written, $hasher->hash($destination), null);
+    }
+
+    /**
+     * Detects the dominant end-of-line sequence used by `$content`.
+     *
+     * Returns `"\r\n"` for Windows-style content, `"\r"` for legacy Mac-style content, and `"\n"` otherwise (Unix or
+     * empty). The result is used to emit appended lines in the same EOL style as the destination so the file does not
+     * end up with mixed line endings.
+     *
+     * @param string $content Original (un-normalised) destination content.
+     *
+     * @return string The detected EOL sequence.
+     */
+    private static function detectEol(string $content): string
+    {
+        if (str_contains($content, "\r\n")) {
+            return "\r\n";
+        }
+
+        if (str_contains($content, "\r")) {
+            return "\r";
+        }
+
+        return "\n";
     }
 
     /**

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -9,14 +9,19 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
+use function array_diff;
+use function explode;
+use function implode;
+use function rtrim;
 use function sprintf;
+use function str_ends_with;
 
 /**
- * Applies a scaffold file by appending its content to an existing destination, or writing it fresh.
+ * Applies a scaffold file by line-merging its content into the destination, or writing it fresh.
  *
- * **Callers are responsible for consulting `scaffold-lock.json`** before invoking this mode. Invoking it without a
- * prior lock check will duplicate content on every call. `Scaffolder` enforces this contract by skipping already-locked
- * append entries on partial runs (`$fullScaffold = false`).
+ * Idempotent by design: when the destination already exists, only provider lines that are not already present in the
+ * destination are appended. Repeated applications produce no duplication, and consumer-specific additions are never
+ * removed.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -32,17 +37,40 @@ final class AppendMode implements ModeInterface
         $destination = PathResolver::destination($projectRoot, $mapping->destination);
         $source = PathResolver::source($mapping->providerPath, $mapping->source);
 
-        $content = file_get_contents($source);
+        $providerContent = file_get_contents($source);
 
-        if ($content === false) {
+        if ($providerContent === false) {
             throw new RuntimeException(sprintf('Could not read source file "%s".', $source));
         }
 
         PathResolver::ensureDirectory($destination);
 
-        $flags = file_exists($destination) ? FILE_APPEND : 0;
+        if (!file_exists($destination)) {
+            if (file_put_contents($destination, $providerContent) === false) {
+                throw new RuntimeException(sprintf('Could not write to "%s".', $destination));
+            }
 
-        if (file_put_contents($destination, $content, $flags) === false) {
+            return new ApplyResult(ApplyOutcome::Written, $hasher->hash($destination), null);
+        }
+
+        $consumerContent = file_get_contents($destination);
+
+        if ($consumerContent === false) {
+            throw new RuntimeException(sprintf('Could not read source file "%s".', $destination));
+        }
+
+        $consumerLines = $consumerContent === '' ? [] : explode("\n", rtrim($consumerContent, "\n"));
+        $providerLines = $providerContent === '' ? [] : explode("\n", rtrim($providerContent, "\n"));
+        $missing = array_diff($providerLines, $consumerLines);
+
+        if ($missing === []) {
+            return new ApplyResult(ApplyOutcome::Skipped, $hasher->hash($destination), null);
+        }
+
+        $separator = $consumerContent === '' || str_ends_with($consumerContent, "\n") ? '' : "\n";
+        $appendData = $separator . implode("\n", $missing) . "\n";
+
+        if (file_put_contents($destination, $appendData, FILE_APPEND) === false) {
             throw new RuntimeException(sprintf('Could not write to "%s".', $destination));
         }
 

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -12,6 +12,7 @@ use yii\scaffold\Scaffold\PathResolver;
 use function array_diff;
 use function explode;
 use function implode;
+use function preg_replace;
 use function rtrim;
 use function sprintf;
 use function str_ends_with;
@@ -58,6 +59,10 @@ final class AppendMode implements ModeInterface
         if ($consumerContent === false) {
             throw new RuntimeException(sprintf('Could not read destination file "%s".', $destination));
         }
+
+        // Normalise line endings so CRLF/CR destinations diff identically against an LF stub.
+        $providerContent = (string) preg_replace('/\r\n|\r/', "\n", $providerContent);
+        $consumerContent = (string) preg_replace('/\r\n|\r/', "\n", $consumerContent);
 
         $consumerLines = $consumerContent === '' ? [] : explode("\n", rtrim($consumerContent, "\n"));
         $providerLines = $providerContent === '' ? [] : explode("\n", rtrim($providerContent, "\n"));

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -13,9 +13,9 @@ use function array_count_values;
 use function explode;
 use function implode;
 use function preg_replace;
-use function rtrim;
 use function sprintf;
 use function str_ends_with;
+use function substr;
 
 /**
  * Applies a scaffold file by line-merging its content into the destination, or writing it fresh.
@@ -64,8 +64,8 @@ final class AppendMode implements ModeInterface
         $providerContent = (string) preg_replace('/\r\n|\r/', "\n", $providerContent);
         $consumerContent = (string) preg_replace('/\r\n|\r/', "\n", $consumerContent);
 
-        $consumerLines = $consumerContent === '' ? [] : explode("\n", rtrim($consumerContent, "\n"));
-        $providerLines = $providerContent === '' ? [] : explode("\n", rtrim($providerContent, "\n"));
+        $consumerLines = self::splitLines($consumerContent);
+        $providerLines = self::splitLines($providerContent);
 
         // Count-based diff preserves multiplicity: a stub with two 'alpha' lines whose destination has only one
         // appends the second occurrence instead of dropping it as set-based 'array_diff' would.
@@ -94,5 +94,29 @@ final class AppendMode implements ModeInterface
         }
 
         return new ApplyResult(ApplyOutcome::Written, $hasher->hash($destination), null);
+    }
+
+    /**
+     * Splits a normalised text into its constituent lines, stripping at most one trailing newline.
+     *
+     * Stripping only the final EOL marker (not every trailing newline) preserves any intentional blank lines at the
+     * end of the file. Otherwise repeated runs would re-detect the trailing blank as missing on every full scaffold,
+     * defeating idempotency.
+     *
+     * @param string $content Normalised text whose lines must be extracted.
+     *
+     * @return list<string> Ordered list of lines, never including a synthetic trailing empty entry from the final EOL.
+     */
+    private static function splitLines(string $content): array
+    {
+        if ($content === '') {
+            return [];
+        }
+
+        if (str_ends_with($content, "\n")) {
+            $content = substr($content, 0, -1);
+        }
+
+        return explode("\n", $content);
     }
 }

--- a/src/Scaffold/Modes/AppendMode.php
+++ b/src/Scaffold/Modes/AppendMode.php
@@ -9,7 +9,7 @@ use yii\scaffold\Manifest\FileMapping;
 use yii\scaffold\Scaffold\Lock\Hasher;
 use yii\scaffold\Scaffold\PathResolver;
 
-use function array_diff;
+use function array_count_values;
 use function explode;
 use function implode;
 use function preg_replace;
@@ -66,7 +66,21 @@ final class AppendMode implements ModeInterface
 
         $consumerLines = $consumerContent === '' ? [] : explode("\n", rtrim($consumerContent, "\n"));
         $providerLines = $providerContent === '' ? [] : explode("\n", rtrim($providerContent, "\n"));
-        $missing = array_diff($providerLines, $consumerLines);
+
+        // Count-based diff preserves multiplicity: a stub with two 'alpha' lines whose destination has only one
+        // appends the second occurrence instead of dropping it as set-based 'array_diff' would.
+        $consumerCounts = array_count_values($consumerLines);
+        $missing = [];
+
+        foreach ($providerLines as $line) {
+            if (isset($consumerCounts[$line]) && $consumerCounts[$line] > 0) {
+                $consumerCounts[$line]--;
+
+                continue;
+            }
+
+            $missing[] = $line;
+        }
 
         if ($missing === []) {
             return new ApplyResult(ApplyOutcome::Skipped, $hasher->hash($destination), null);

--- a/src/Scaffold/Modes/ApplyResult.php
+++ b/src/Scaffold/Modes/ApplyResult.php
@@ -10,11 +10,11 @@ namespace yii\scaffold\Scaffold\Modes;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class ApplyResult
+final readonly class ApplyResult
 {
     public function __construct(
-        public readonly ApplyOutcome $outcome,
-        public readonly string $newHash,
-        public readonly string|null $warning,
+        public ApplyOutcome $outcome,
+        public string $newHash,
+        public string|null $warning,
     ) {}
 }

--- a/src/Scaffold/PathResolver.php
+++ b/src/Scaffold/PathResolver.php
@@ -54,7 +54,7 @@ final class PathResolver
     {
         $dir = dirname($absoluteFilePath);
 
-        if (!is_dir($dir) && mkdir($dir, 0777, recursive: true) === false && !is_dir($dir)) {
+        if (!is_dir($dir) && mkdir($dir, 0o777, recursive: true) === false && !is_dir($dir)) {
             throw new RuntimeException(sprintf('Could not create directory "%s".', $dir));
         }
     }
@@ -172,6 +172,6 @@ final class PathResolver
 
         $currentUmask = umask();
 
-        @chmod($destination, $perms & 0777 & ~$currentUmask);
+        @chmod($destination, $perms & 0o777 & ~$currentUmask);
     }
 }

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -27,19 +27,19 @@ use function substr;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class Scaffolder
+final readonly class Scaffolder
 {
     /**
      * @var array<string, ModeInterface> Pre-instantiated mode implementations keyed by the backing value of
      * {@see FileMode} for efficient resolution during scaffolding.
      */
-    private readonly array $modes;
+    private array $modes;
 
     public function __construct(
-        private readonly ManifestLoader $loader,
-        private readonly Applier $applier,
-        private readonly LockFile $lockFile,
-        private readonly IOInterface $io,
+        private ManifestLoader $loader,
+        private Applier $applier,
+        private LockFile $lockFile,
+        private IOInterface $io,
     ) {
         $this->modes = [
             FileMode::Replace->value => new ReplaceMode(),

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -172,14 +172,21 @@ final readonly class Scaffolder
                         'mode' => $mapping->mode->value,
                     ];
                     $dirty = true;
-                } elseif ($result->newHash !== '' && !isset($lockData['files'][$destination])) {
-                    $lockData['files'][$destination] = [
-                        'hash' => $result->newHash,
+                } elseif ($result->newHash !== '') {
+                    // Refresh ownership metadata when a different provider claims the file but the on-disk content
+                    // is already in sync; the hash is left intact so replace-mode user-modification detection keeps
+                    // its original baseline.
+                    $expected = [
+                        'hash' => $lockData['files'][$destination]['hash'] ?? $result->newHash,
                         'provider' => $mapping->providerName,
                         'source' => $mapping->source,
                         'mode' => $mapping->mode->value,
                     ];
-                    $dirty = true;
+
+                    if (($lockData['files'][$destination] ?? null) !== $expected) {
+                        $lockData['files'][$destination] = $expected;
+                        $dirty = true;
+                    }
                 }
             } catch (Throwable $e) {
                 $this->io->writeError(

--- a/src/Scaffold/Scaffolder.php
+++ b/src/Scaffold/Scaffolder.php
@@ -88,14 +88,14 @@ final readonly class Scaffolder
             return;
         }
 
-        // index installed packages by name for O(1) lookup.
+        // Index installed packages by name for O(1) lookup.
         $byName = [];
 
         foreach ($installedPackages as $package) {
             $byName[$package->getName()] = $package;
         }
 
-        // merge file mappings in allowed-packages order; last provider wins for duplicate destinations.
+        // Merge file mappings in allowed-packages order; last provider wins for duplicate destinations.
         $merged = [];
         $providerEntries = [];
 

--- a/src/Security/PackageAllowlist.php
+++ b/src/Security/PackageAllowlist.php
@@ -17,12 +17,12 @@ use function in_array;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class PackageAllowlist
+final readonly class PackageAllowlist
 {
     /**
      * @param list<string> $allowedPackages Package names from `extra.scaffold.allowed-packages`.
      */
-    public function __construct(private readonly array $allowedPackages) {}
+    public function __construct(private array $allowedPackages) {}
 
     /**
      * Asserts that the given package is authorized to write scaffold files.

--- a/src/Services/DiffService.php
+++ b/src/Services/DiffService.php
@@ -14,7 +14,6 @@ use yii\scaffold\Security\PathValidator;
 
 use function implode;
 use function is_file;
-use function is_string;
 use function preg_replace;
 use function rtrim;
 use function sprintf;
@@ -49,13 +48,12 @@ final class DiffService
 
         $differ = new Differ(new DiffOnlyOutputBuilder(''));
 
+        /** @var list<array{0: string, 1: int}> $entries */
         $entries = $differ->diffToArray($stubContent, $currentContent);
 
         $output = [];
 
         foreach ($entries as [$line, $type]) {
-            $line = is_string($line) ? $line : '';
-
             if ($type === Differ::REMOVED) {
                 $output[] = '- ' . rtrim($line, "\n");
             } elseif ($type === Differ::ADDED) {

--- a/src/Services/StatusService.php
+++ b/src/Services/StatusService.php
@@ -99,10 +99,10 @@ final class StatusService
             return ExitCode::Ok->value;
         }
 
-        $colFile = max(4, max(array_map('strlen', array_keys($statuses))));
-        $colProvider = max(8, max(array_map('strlen', array_column($statuses, 'provider'))));
-        $colMode = max(4, max(array_map('strlen', array_column($statuses, 'mode'))));
-        $colStatus = max(6, max(array_map('strlen', array_column($statuses, 'status'))));
+        $colFile = max(4, max(array_map(strlen(...), array_keys($statuses))));
+        $colProvider = max(8, max(array_map(strlen(...), array_column($statuses, 'provider'))));
+        $colMode = max(4, max(array_map(strlen(...), array_column($statuses, 'mode'))));
+        $colStatus = max(6, max(array_map(strlen(...), array_column($statuses, 'status'))));
         $separator = str_repeat('-', $colFile + $colProvider + $colMode + $colStatus + 6);
 
         $out->writeStdout(

--- a/tests/functional/ComposerInstallTest.php
+++ b/tests/functional/ComposerInstallTest.php
@@ -251,7 +251,7 @@ final class ComposerInstallTest extends TestCase
 
         $subscriber->onPostInstall($this->makePostInstallEvent($composer, $io));
 
-        // simulate the user editing the replace-mode file between two install runs.
+        // Simulate the user editing the replace-mode file between two install runs.
         file_put_contents(
             $builder->getProjectRoot() . '/.env.dist',
             "APP_ENV=production\nUSER_EDIT=1\n",

--- a/tests/functional/CreateProjectTest.php
+++ b/tests/functional/CreateProjectTest.php
@@ -46,7 +46,7 @@ final class CreateProjectTest extends TestCase
             ],
         );
 
-        // pre-populate the lock so partial scaffold (fullScaffold=false) would skip '.gitignore'.
+        // Pre-populate the lock so partial scaffold (fullScaffold=false) would skip '.gitignore'.
         $builder->createProjectFile('.gitignore', "existing\n");
 
         (new LockFile($builder->getProjectRoot()))->write(
@@ -162,7 +162,7 @@ final class CreateProjectTest extends TestCase
 
         $subscriber = new EventSubscriber();
 
-        // composer create-project fires post-install-cmd first, then post-create-project-cmd within the same process.
+        // Composer 'create-project' fires post-install-cmd first, then post-create-project-cmd within the same process.
         $subscriber->onPostInstall($this->makePostInstallEvent($composer, $io));
         $subscriber->onPostCreateProject($this->makePostCreateProjectEvent($composer, $io));
 

--- a/tests/functional/MultiLayerCompositionTest.php
+++ b/tests/functional/MultiLayerCompositionTest.php
@@ -37,7 +37,7 @@ final class MultiLayerCompositionTest extends TestCase
                 'name' => 'demo/composition',
                 'config' => ['vendor-dir' => $builder->getVendorDir()],
                 'extra' => [
-                    // provider-b is listed last, so its stub must win.
+                    // Provider 'provider-b' is listed last, so its stub must win.
                     'scaffold' => [
                         'allowed-packages' => [
                             'demo/provider-a',
@@ -80,7 +80,7 @@ final class MultiLayerCompositionTest extends TestCase
                 'name' => 'demo/composition',
                 'config' => ['vendor-dir' => $builder->getVendorDir()],
                 'extra' => [
-                    // now provider-a is listed last.
+                    // Now provider-a is listed last.
                     'scaffold' => [
                         'allowed-packages' => [
                             'demo/provider-b',

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -92,6 +92,52 @@ final class ScaffolderTest extends TestCase
         );
     }
 
+    public function testAppendModeRefreshesLockOwnershipWhenNewProviderClaimsExistingFile(): void
+    {
+        $builder = new FakeProjectBuilder($this->tempDir);
+
+        // Two providers ship the same '.gitignore' content; the destination already matches both stubs identically.
+        $builder->createStubFile('yii2-extensions/old-provider', '.gitignore', "*.log\n");
+        $builder->createStubFile('yii2-extensions/new-provider', '.gitignore', "*.log\n");
+        $builder->createProjectFile('.gitignore', "*.log\n");
+
+        $oldProvider = $this->makeProviderPackage(
+            'yii2-extensions/old-provider',
+            ['scaffold' => ['copy' => ['.gitignore'], 'modes' => ['.gitignore' => 'append']]],
+        );
+        $newProvider = $this->makeProviderPackage(
+            'yii2-extensions/new-provider',
+            ['scaffold' => ['copy' => ['.gitignore'], 'modes' => ['.gitignore' => 'append']]],
+        );
+
+        // First run: only the old provider is allowed; lock records its ownership.
+        $oldRoot = $this->makeRootPackage(['yii2-extensions/old-provider']);
+        $oldScaffolder = $this->makeScaffolder(['yii2-extensions/old-provider'], $builder);
+        $oldScaffolder->scaffold($oldRoot, [$oldProvider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $oldLock = (new LockFile($builder->getProjectRoot()))->read();
+
+        self::assertSame(
+            'yii2-extensions/old-provider',
+            $oldLock['files']['.gitignore']['provider'] ?? null,
+            'Initial scaffold must record the old provider as the owner.',
+        );
+
+        // Second run: only the new provider is allowed. AppendMode finds no missing lines (Skipped) but the
+        // ownership metadata must be refreshed to point to the new provider.
+        $newRoot = $this->makeRootPackage(['yii2-extensions/new-provider']);
+        $newScaffolder = $this->makeScaffolder(['yii2-extensions/new-provider'], $builder);
+        $newScaffolder->scaffold($newRoot, [$newProvider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
+
+        $newLock = (new LockFile($builder->getProjectRoot()))->read();
+
+        self::assertSame(
+            'yii2-extensions/new-provider',
+            $newLock['files']['.gitignore']['provider'] ?? null,
+            'Skipped append must refresh the lock ownership metadata when a different provider claims the file.',
+        );
+    }
+
     public function testAppendModeSkippedOnInstallWhenAlreadyInLock(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -31,7 +31,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        // root authorizes a provider that was never added to the installed-packages list.
+        // Root authorizes a provider that was never added to the installed-packages list.
         $root = $this->makeRootPackage(['yii2-extensions/missing']);
 
         $io = new BufferIO();
@@ -75,12 +75,12 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first run: full scaffold writes the missing line.
+        // First run: full scaffold writes the missing line.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/.gitignore');
 
-        // second full scaffold: every provider line is already present, so nothing should change.
+        // Second full scaffold: every provider line is already present, so nothing should change.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterSecond = file_get_contents($builder->getProjectRoot() . '/.gitignore');
@@ -111,12 +111,12 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first run: full scaffold writes the append and records lock.
+        // First run: full scaffold writes the append and records lock.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/.gitignore');
 
-        // second run: partial (install) append is already in lock, must be skipped.
+        // Second run: partial (install) append is already in lock, must be skipped.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
 
         self::assertSame(
@@ -145,7 +145,7 @@ final class ScaffolderTest extends TestCase
 
         $io = new BufferIO();
 
-        // allowlist only admits a DIFFERENT provider, so assertAllowed throws RuntimeException during apply().
+        // Allowlist only admits a DIFFERENT provider, so assertAllowed throws RuntimeException during apply().
         $scaffolder = new Scaffolder(
             new ManifestLoader(new ManifestSchema(), new ManifestExpander()),
             new Applier(new PackageAllowlist(['safe/other']), new PathValidator(), new Hasher(), $io),
@@ -178,7 +178,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        // root with `extra.scaffold` present but the allowed-packages list explicitly empty.
+        // Root with `extra.scaffold` present but the allowed-packages list explicitly empty.
         $root = self::createStub(PackageInterface::class);
         $root->method('getExtra')->willReturn(['scaffold' => ['allowed-packages' => []]]);
 
@@ -203,7 +203,7 @@ final class ScaffolderTest extends TestCase
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
-        // provider has no scaffold extra at all; loader returns an empty mapping list and the lock stays untouched.
+        // Provider has no scaffold extra at all; loader returns an empty mapping list and the lock stays untouched.
         $provider = $this->makeProviderPackage('yii2-extensions/empty', []);
         $root = $this->makeRootPackage(['yii2-extensions/empty']);
 
@@ -528,7 +528,7 @@ final class ScaffolderTest extends TestCase
             $bufferIo,
         );
 
-        // note: only 'good' is passed as installed; 'missing' is absent.
+        // Note: only 'good' is passed as installed; 'missing' is absent.
         $scaffolder->scaffold($root, [$good], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         self::assertStringContainsString(
@@ -642,7 +642,7 @@ final class ScaffolderTest extends TestCase
     {
         $method = new ReflectionMethod(Scaffolder::class, 'prefixMatches');
 
-        // case-sensitive branch matches identical casing but rejects differing casing.
+        // Case-sensitive branch matches identical casing but rejects differing casing.
         self::assertTrue(
             (bool) $method->invoke(null, '/Project/vendor/foo', '/Project/', false),
             'Byte-exact comparison must accept an exact casing prefix.',
@@ -683,7 +683,7 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first run records a lock entry for the prepend mapping.
+        // First run records a lock entry for the prepend mapping.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/prepend.txt');
@@ -717,12 +717,12 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first run records the current hash in the lock.
+        // First run records the current hash in the lock.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $initialHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('config.php');
 
-        // user modifies the file in place; a second preserve run must NOT overwrite the lock entry.
+        // User modifies the file in place; a second preserve run must NOT overwrite the lock entry.
         file_put_contents($builder->getProjectRoot() . '/config.php', 'user-modified');
 
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
@@ -874,7 +874,7 @@ final class ScaffolderTest extends TestCase
 
         $firstHash = (new LockFile($builder->getProjectRoot()))->getHashAtScaffold('app.php');
 
-        // change the stub so the second run writes different content.
+        // Change the stub so the second run writes different content.
         $builder->createStubFile('yii2-extensions/test', 'app.php', 'v2');
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
@@ -968,13 +968,13 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first full run records both entries in the lock.
+        // First full run records both entries in the lock.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
-        // delete `fresh.txt` so the second run must re-create it even though `append.txt` is locked and skipped first.
+        // Delete `fresh.txt` so the second run must re-create it even though `append.txt` is locked and skipped first.
         unlink($builder->getProjectRoot() . '/fresh.txt');
 
-        // partial run: append.txt is skipped (continue), but the loop must continue to process fresh.txt.
+        // Partial run: 'append.txt' is skipped (continue), but the loop must continue to process fresh.txt.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), false);
 
         self::assertFileExists(

--- a/tests/functional/ScaffolderTest.php
+++ b/tests/functional/ScaffolderTest.php
@@ -56,7 +56,7 @@ final class ScaffolderTest extends TestCase
         );
     }
 
-    public function testAppendModeAppliedOnFullScaffoldEvenIfAlreadyInLock(): void
+    public function testAppendModeIsIdempotentOnFullScaffold(): void
     {
         $builder = new FakeProjectBuilder($this->tempDir);
 
@@ -75,20 +75,20 @@ final class ScaffolderTest extends TestCase
         $root = $this->makeRootPackage(['yii2-extensions/test']);
         $scaffolder = $this->makeScaffolder(['yii2-extensions/test'], $builder);
 
-        // first run: full scaffold writes append.
+        // first run: full scaffold writes the missing line.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterFirst = file_get_contents($builder->getProjectRoot() . '/.gitignore');
 
-        // second full scaffold: re-appends even though entry exists in lock.
+        // second full scaffold: every provider line is already present, so nothing should change.
         $scaffolder->scaffold($root, [$provider], $builder->getProjectRoot(), $builder->getVendorDir(), true);
 
         $afterSecond = file_get_contents($builder->getProjectRoot() . '/.gitignore');
 
-        self::assertNotSame(
+        self::assertSame(
             $afterFirst,
             $afterSecond,
-            'Append mode file should be re-appended on full scaffold even if already in lock.',
+            'Append mode must be idempotent on full scaffold and never duplicate provider lines already present.',
         );
     }
 
@@ -291,7 +291,7 @@ final class ScaffolderTest extends TestCase
 
         $providerRootInsideProject = $builder->getProjectRoot() . '/vendor/yii2-extensions/test';
 
-        mkdir($providerRootInsideProject, 0777, recursive: true);
+        mkdir($providerRootInsideProject, 0o777, recursive: true);
         file_put_contents($providerRootInsideProject . '/app.php', 'a');
 
         $provider = $this->makeProviderPackage(
@@ -373,7 +373,7 @@ final class ScaffolderTest extends TestCase
         );
         self::assertCount(
             1,
-            array_filter(array_keys($lockData['files']), static fn(string $k) => $k === 'app.php'),
+            array_filter(array_keys($lockData['files']), static fn(string $k): bool => $k === 'app.php'),
             "Lock must contain exactly one entry for 'app.php'.",
         );
         self::assertSame(

--- a/tests/support/FakeProjectBuilder.php
+++ b/tests/support/FakeProjectBuilder.php
@@ -12,10 +12,10 @@ use RuntimeException;
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
  */
-final class FakeProjectBuilder
+final readonly class FakeProjectBuilder
 {
-    private readonly string $projectRoot;
-    private readonly string $vendorDir;
+    private string $projectRoot;
+    private string $vendorDir;
 
     public function __construct(string $tempBase)
     {
@@ -23,14 +23,14 @@ final class FakeProjectBuilder
         $this->vendorDir = $tempBase . '/vendor';
 
         if (!is_dir($this->projectRoot)
-            && mkdir($this->projectRoot, 0777, recursive: true) === false
+            && mkdir($this->projectRoot, 0o777, recursive: true) === false
             && !is_dir($this->projectRoot)
         ) {
             throw new RuntimeException(sprintf('Could not create project root "%s".', $this->projectRoot));
         }
 
         if (!is_dir($this->vendorDir)
-            && mkdir($this->vendorDir, 0777, recursive: true) === false
+            && mkdir($this->vendorDir, 0o777, recursive: true) === false
             && !is_dir($this->vendorDir)
         ) {
             throw new RuntimeException(sprintf('Could not create vendor dir "%s".', $this->vendorDir));
@@ -68,7 +68,7 @@ final class FakeProjectBuilder
         $full = $this->projectRoot . '/' . $relPath;
         $dir = dirname($full);
 
-        if (!is_dir($dir) && mkdir($dir, 0777, recursive: true) === false && !is_dir($dir)) {
+        if (!is_dir($dir) && mkdir($dir, 0o777, recursive: true) === false && !is_dir($dir)) {
             throw new RuntimeException(sprintf('Could not create directory "%s".', $dir));
         }
 
@@ -89,7 +89,7 @@ final class FakeProjectBuilder
         $full = $this->vendorDir . '/' . $providerName . '/' . $relPath;
         $dir = dirname($full);
 
-        if (!is_dir($dir) && mkdir($dir, 0777, recursive: true) === false && !is_dir($dir)) {
+        if (!is_dir($dir) && mkdir($dir, 0o777, recursive: true) === false && !is_dir($dir)) {
             throw new RuntimeException(sprintf('Could not create directory "%s".', $dir));
         }
 

--- a/tests/support/TempDirectoryTrait.php
+++ b/tests/support/TempDirectoryTrait.php
@@ -52,7 +52,7 @@ trait TempDirectoryTrait
             return;
         }
 
-        if (mkdir($path, 0777, recursive: true) === false && !is_dir($path)) {
+        if (mkdir($path, 0o777, recursive: true) === false && !is_dir($path)) {
             self::fail(sprintf('Failed to create test directory "%s".', $path));
         }
     }
@@ -68,7 +68,7 @@ trait TempDirectoryTrait
     {
         $path = sys_get_temp_dir() . '/scaffold-test-' . uniqid('', true);
 
-        if (mkdir($path, 0777, recursive: true) === false) {
+        if (mkdir($path, 0o777, recursive: true) === false) {
             throw new RuntimeException(sprintf('Could not create temp directory "%s".', $path));
         }
 

--- a/tests/support/internal-mocker-stubs.php
+++ b/tests/support/internal-mocker-stubs.php
@@ -12,7 +12,7 @@ if (is_array($stubs) === false) {
     $stubs = [];
 }
 
-// override PHP `8.0+` "optional before required" deprecations by giving `$context` a default null.
+// Override PHP `8.0+` "optional before required" deprecations by giving `$context` a default null.
 $stubs['mkdir'] = [
     'signatureArguments' => 'string $directory, int $permissions = 0777, bool $recursive = false, $context = null',
     'arguments' => '$directory, $permissions, $recursive, $context',

--- a/tests/unit/EventSubscriberTest.php
+++ b/tests/unit/EventSubscriberTest.php
@@ -23,6 +23,36 @@ use yii\scaffold\EventSubscriber;
 #[Group('scaffold')]
 final class EventSubscriberTest extends TestCase
 {
+    public function testOnPostCreateProjectShortCircuitsWhenInstallScaffoldRanIsTrue(): void
+    {
+        $reflection = new ReflectionClass(EventSubscriber::class);
+
+        $property = $reflection->getProperty('installScaffoldRan');
+
+        $property->setValue(null, true);
+
+        $io = new BufferIO();
+
+        $config = self::createStub(Config::class);
+
+        // An empty 'vendor-dir' would cause 'runScaffold' to write the 'Unable to resolve vendor-dir' error message.
+        // The early return must prevent 'runScaffold' from being reached, so the buffer must remain empty.
+        $config->method('get')->willReturn('');
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getConfig')->willReturn($config);
+
+        (new EventSubscriber())->onPostCreateProject(
+            new ScriptEvent(ScriptEvents::POST_CREATE_PROJECT_CMD, $composer, $io, true),
+        );
+
+        self::assertSame(
+            '',
+            $io->getOutput(),
+            "'onPostCreateProject' must short-circuit silently when 'installScaffoldRan' is 'true'.",
+        );
+    }
     public function testRegistersPostCreateProjectCmd(): void
     {
         self::assertArrayHasKey(

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -253,7 +253,7 @@ final class ManifestExpanderTest extends TestCase
                 ],
             );
         } finally {
-            chmod("{$this->tempDir}/vendor", 0755);
+            chmod("{$this->tempDir}/vendor", 0o755);
         }
 
         self::assertSame(
@@ -281,7 +281,7 @@ final class ManifestExpanderTest extends TestCase
                 ],
             );
         } finally {
-            chmod("{$this->tempDir}/secrets", 0755);
+            chmod("{$this->tempDir}/secrets", 0o755);
         }
 
         self::assertSame(

--- a/tests/unit/Scaffold/ApplierTest.php
+++ b/tests/unit/Scaffold/ApplierTest.php
@@ -32,7 +32,7 @@ final class ApplierTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('destination');
 
-        // traversal is caught before the realpath check; no real project dir needed.
+        // Traversal is caught before the realpath check; no real project dir needed.
         $this->makeApplier()->apply(
             $this->makeMapping(destination: '../../../etc/passwd'),
             "{$this->tempDir}/project",
@@ -93,7 +93,7 @@ final class ApplierTest extends TestCase
 
     public function testSourceTraversalThrows(): void
     {
-        // validateDestination runs first and needs the project dir to exist.
+        // 'validateDestination' runs first and needs the project dir to exist.
         $projectDir = "{$this->tempDir}/project";
 
         mkdir($projectDir, 0o777, recursive: true);

--- a/tests/unit/Scaffold/ApplierTest.php
+++ b/tests/unit/Scaffold/ApplierTest.php
@@ -45,7 +45,7 @@ final class ApplierTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
         $this->makeSourceFile();
@@ -67,7 +67,7 @@ final class ApplierTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
         $this->makeSourceFile('stub');
@@ -96,7 +96,7 @@ final class ApplierTest extends TestCase
         // validateDestination runs first and needs the project dir to exist.
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('source');
@@ -126,7 +126,7 @@ final class ApplierTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user-modified content');
 
         $this->makeSourceFile('stub content');
@@ -167,7 +167,7 @@ final class ApplierTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
 
         $this->makeSourceFile();
         $result = $this->makeApplier()->apply(

--- a/tests/unit/Scaffold/Lock/HasherTest.php
+++ b/tests/unit/Scaffold/Lock/HasherTest.php
@@ -117,7 +117,7 @@ final class HasherTest extends TestCase
 
         file_put_contents($file, 'content');
 
-        // force `is_readable()` inside the Lock namespace to report false while the file still exists.
+        // Force `is_readable()` inside the Lock namespace to report false while the file still exists.
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'is_readable',
@@ -137,7 +137,7 @@ final class HasherTest extends TestCase
 
         file_put_contents($file, 'content');
 
-        // real file is readable; force `hash_file()` itself to report false to hit the post-read failure branch.
+        // Real file is readable; force `hash_file()` itself to report false to hit the post-read failure branch.
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'hash_file',

--- a/tests/unit/Scaffold/Lock/LockFileTest.php
+++ b/tests/unit/Scaffold/Lock/LockFileTest.php
@@ -139,7 +139,7 @@ final class LockFileTest extends TestCase
 
         $first = $lock->read();
 
-        // remove the file from disk subsequent reads must still hit the in-memory cache.
+        // Remove the file from disk subsequent reads must still hit the in-memory cache.
         unlink($this->tempDir . '/scaffold-lock.json');
 
         self::assertSame(
@@ -205,7 +205,7 @@ final class LockFileTest extends TestCase
     {
         $lock = new LockFile($this->tempDir);
 
-        // ask the LockFile for the exact path so the mocker match honors the platform's DIRECTORY_SEPARATOR.
+        // Ask the LockFile for the exact path so the mocker match honors the platform's DIRECTORY_SEPARATOR.
         $path = $lock->getPath();
 
         file_put_contents($path, '{"providers":{},"files":{}}');
@@ -225,7 +225,7 @@ final class LockFileTest extends TestCase
 
     public function testReadThrowsWhenJsonDecodesToNonObject(): void
     {
-        // valid JSON, but it decodes to a scalar `is_array($decoded)` must be `false`, triggering the structural check.
+        // Valid JSON, but it decodes to a scalar `is_array($decoded)` must be `false`, triggering the structural check.
         file_put_contents($this->tempDir . '/scaffold-lock.json', '"just a string"');
 
         $this->expectException(RuntimeException::class);
@@ -305,7 +305,7 @@ final class LockFileTest extends TestCase
 
         $tmp = "{$path}.tmp";
 
-        // simulate `file_put_contents` succeeding but `rename` failing, exercising the cleanup + throw branch.
+        // Simulate `file_put_contents` succeeding but `rename` failing, exercising the cleanup + throw branch.
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'rename',

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -45,6 +45,31 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testAppendsRepeatedProviderLinesWhenDestinationHasFewer(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Destination has one 'alpha'; stub has two. The second occurrence must be appended (multiplicity-preserving).
+        file_put_contents($projectDir . '/output.txt', "alpha\n");
+
+        $this->makeSourceFile("alpha\nalpha\n");
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            "alpha\nalpha\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must preserve provider line multiplicity instead of treating destination lines as a set.',
+        );
+    }
+
     public function testCreatesIntermediateDirectories(): void
     {
         $this->makeSourceFile(relative: 'stubs/nested/deep.txt');

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -191,6 +191,37 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testNormalizesLineEndingsBeforeDiffing(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Destination uses CRLF (typical for files checked out on Windows or repos with mixed EOL).
+        file_put_contents($projectDir . '/output.txt', "alpha\r\nbeta\r\n");
+
+        // Provider ships LF.
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'AppendMode must normalise line endings so CRLF destinations match LF stubs.',
+        );
+        self::assertSame(
+            "alpha\r\nbeta\r\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must leave the destination untouched when EOL-normalised content matches.',
+        );
+    }
+
     public function testRtrimsTrailingNewlineFromConsumerBeforeDiffing(): void
     {
         $projectDir = "{$this->tempDir}/project";

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -216,6 +216,63 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testThrowsWhenAppendWriteFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "existing\n");
+
+        // Source has a line not present in the destination, so the append-write path is reached.
+        $this->makeSourceFile("missing\n");
+
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_put_contents',
+            [],
+            false,
+            default: true,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not write to');
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+    }
+
+    public function testThrowsWhenDestinationReadFails(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', 'existing');
+
+        $this->makeSourceFile('extra');
+
+        // Mock the destination read by exact path to fail; the source read (different path) is unaffected.
+        MockerState::addCondition(
+            'yii\\scaffold\\Scaffold\\Modes',
+            'file_get_contents',
+            [$projectDir . DIRECTORY_SEPARATOR . 'output.txt', false, null, 0, null],
+            false,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Could not read destination file');
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+    }
+
     public function testThrowsWhenSourceReadFails(): void
     {
         $this->makeSourceFile('x');

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -90,6 +90,37 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testNormalizesLineEndingsBeforeDiffing(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Destination uses CRLF (typical for files checked out on Windows or repos with mixed EOL).
+        file_put_contents($projectDir . '/output.txt', "alpha\r\nbeta\r\n");
+
+        // Provider ships LF.
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'AppendMode must normalise line endings so CRLF destinations match LF stubs.',
+        );
+        self::assertSame(
+            "alpha\r\nbeta\r\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must leave the destination untouched when EOL-normalised content matches.',
+        );
+    }
+
     public function testPreservesConsumerAdditionsOnRepeatedApplies(): void
     {
         $projectDir = "{$this->tempDir}/project";
@@ -188,37 +219,6 @@ final class AppendModeTest extends TestCase
             ApplyOutcome::Written,
             $result->outcome,
             "AppendMode must return 'ApplyOutcome::Written' when at least one missing line is appended.",
-        );
-    }
-
-    public function testNormalizesLineEndingsBeforeDiffing(): void
-    {
-        $projectDir = "{$this->tempDir}/project";
-
-        mkdir($projectDir, 0o777, recursive: true);
-
-        // Destination uses CRLF (typical for files checked out on Windows or repos with mixed EOL).
-        file_put_contents($projectDir . '/output.txt', "alpha\r\nbeta\r\n");
-
-        // Provider ships LF.
-        $this->makeSourceFile("alpha\nbeta\n");
-
-        $result = (new AppendMode())->apply(
-            $this->makeMapping(),
-            $projectDir,
-            new Hasher(),
-            null,
-        );
-
-        self::assertSame(
-            ApplyOutcome::Skipped,
-            $result->outcome,
-            'AppendMode must normalise line endings so CRLF destinations match LF stubs.',
-        );
-        self::assertSame(
-            "alpha\r\nbeta\r\n",
-            file_get_contents($projectDir . '/output.txt'),
-            'AppendMode must leave the destination untouched when EOL-normalised content matches.',
         );
     }
 

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -115,6 +115,44 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testIsIdempotentWhenStubEndsWithBlankLine(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Stub ends with an intentional trailing blank line.
+        $this->makeSourceFile("alpha\n\n");
+
+        // Two passes: the first must write the trailing blank; the second must detect it as already present.
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        $afterFirst = file_get_contents($projectDir . '/output.txt');
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            'AppendMode must remain idempotent when the stub ends with a blank line.',
+        );
+        self::assertSame(
+            $afterFirst,
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must not re-append the trailing blank line on subsequent runs.',
+        );
+    }
+
     public function testNormalizesLineEndingsBeforeDiffing(): void
     {
         $projectDir = "{$this->tempDir}/project";

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -92,6 +92,35 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testHandlesEmptyStub(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\n");
+
+        // Empty stub yields zero provider lines; the destination must remain untouched.
+        $this->makeSourceFile('');
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            "AppendMode must return 'ApplyOutcome::Skipped' when the stub is empty.",
+        );
+        self::assertSame(
+            "alpha\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must leave the destination untouched when the stub is empty.',
+        );
+    }
+
     public function testInsertsSeparatorWhenDestinationDoesNotEndWithNewline(): void
     {
         $projectDir = "{$this->tempDir}/project";
@@ -112,6 +141,37 @@ final class AppendModeTest extends TestCase
             "existing\nappended\n",
             file_get_contents($projectDir . '/output.txt'),
             'AppendMode must insert a newline separator when the destination does not end with one.',
+        );
+    }
+
+    public function testIsIdempotentWhenConsumerHasNoTrailingNewlineAndStubDoes(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Destination has no trailing newline; stub ends with one. The trailing-EOL stripping must treat both as
+        // equivalent so no phantom empty line gets appended.
+        file_put_contents($projectDir . '/output.txt', 'alpha');
+
+        $this->makeSourceFile("alpha\n");
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            "AppendMode must treat 'alpha' and 'alpha\\n' as equivalent for diffing purposes.",
+        );
+        self::assertSame(
+            'alpha',
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must not modify a destination that differs from the stub only by the final EOL.',
         );
     }
 

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -92,6 +92,56 @@ final class AppendModeTest extends TestCase
         );
     }
 
+    public function testEmitsAppendedLinesUsingCREolWhenDestinationUsesCR(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Legacy Mac-style CR-only destination.
+        file_put_contents($projectDir . '/output.txt', "alpha\r");
+
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            "alpha\rbeta\r",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must emit appended lines using CR when the destination uses CR-only EOL.',
+        );
+    }
+
+    public function testEmitsAppendedLinesUsingCRLFEolWhenDestinationUsesCRLF(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+
+        // Windows-style CRLF destination.
+        file_put_contents($projectDir . '/output.txt', "alpha\r\n");
+
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            "alpha\r\nbeta\r\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must emit appended lines using CRLF when the destination uses CRLF EOL.',
+        );
+    }
+
     public function testHandlesEmptyStub(): void
     {
         $projectDir = "{$this->tempDir}/project";

--- a/tests/unit/Scaffold/Modes/AppendModeTest.php
+++ b/tests/unit/Scaffold/Modes/AppendModeTest.php
@@ -22,14 +22,14 @@ final class AppendModeTest extends TestCase
 {
     use TempDirectoryTrait;
 
-    public function testAppendsToExistingFile(): void
+    public function testAppendsOnlyMissingLines(): void
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
-        file_put_contents($projectDir . '/output.txt', 'existing');
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\nbeta\n");
 
-        $this->makeSourceFile(' appended');
+        $this->makeSourceFile("alpha\nbeta\ngamma\n");
 
         (new AppendMode())->apply(
             $this->makeMapping(),
@@ -39,9 +39,9 @@ final class AppendModeTest extends TestCase
         );
 
         self::assertSame(
-            'existing appended',
+            "alpha\nbeta\ngamma\n",
             file_get_contents($projectDir . '/output.txt'),
-            'AppendMode must append to the existing file content rather than overwriting it.',
+            'AppendMode must append only the lines not already present in the destination.',
         );
     }
 
@@ -67,26 +67,57 @@ final class AppendModeTest extends TestCase
         );
     }
 
-    public function testOutcomeIsAlwaysWritten(): void
+    public function testInsertsSeparatorWhenDestinationDoesNotEndWithNewline(): void
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
-        $this->makeSourceFile('extra');
+        $this->makeSourceFile('appended');
 
-        $result = (new AppendMode())->apply(
+        (new AppendMode())->apply(
             $this->makeMapping(),
             $projectDir,
             new Hasher(),
-            'sha256:some-recorded-hash',
+            null,
         );
 
         self::assertSame(
-            ApplyOutcome::Written,
-            $result->outcome,
-            "AppendMode must always return 'ApplyOutcome::Written' regardless of the previous file state.",
+            "existing\nappended\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must insert a newline separator when the destination does not end with one.',
+        );
+    }
+
+    public function testPreservesConsumerAdditionsOnRepeatedApplies(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\nproject-specific-line\n");
+
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        // Apply again must remain idempotent.
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            "alpha\nproject-specific-line\nbeta\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must remain idempotent and never duplicate provider lines or remove consumer additions.',
         );
     }
 
@@ -106,6 +137,82 @@ final class AppendModeTest extends TestCase
             $hasher->hash("{$this->tempDir}/project/output.txt"),
             $result->newHash,
             'AppendMode must return a new hash that matches the actual content of the written file.',
+        );
+    }
+
+    public function testReturnsSkippedWhenAllProviderLinesAlreadyPresent(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\nbeta\ngamma\n");
+
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            ApplyOutcome::Skipped,
+            $result->outcome,
+            "AppendMode must return 'ApplyOutcome::Skipped' when every provider line is already present.",
+        );
+        self::assertSame(
+            "alpha\nbeta\ngamma\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must leave the destination untouched when every provider line is already present.',
+        );
+    }
+
+    public function testReturnsWrittenWhenAtLeastOneLineIsAppended(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\n");
+
+        $this->makeSourceFile("alpha\nbeta\n");
+
+        $result = (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            'sha256:some-recorded-hash',
+        );
+
+        self::assertSame(
+            ApplyOutcome::Written,
+            $result->outcome,
+            "AppendMode must return 'ApplyOutcome::Written' when at least one missing line is appended.",
+        );
+    }
+
+    public function testRtrimsTrailingNewlineFromConsumerBeforeDiffing(): void
+    {
+        $projectDir = "{$this->tempDir}/project";
+
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\nbeta\n");
+
+        // Provider declares an explicit empty line between 'alpha' and 'beta'. Without rtrim'ing the consumer the
+        // trailing-newline split would inject a phantom empty entry into the consumer set, masking the missing line.
+        $this->makeSourceFile("alpha\n\nbeta\n");
+
+        (new AppendMode())->apply(
+            $this->makeMapping(),
+            $projectDir,
+            new Hasher(),
+            null,
+        );
+
+        self::assertSame(
+            "alpha\nbeta\n\n",
+            file_get_contents($projectDir . '/output.txt'),
+            'AppendMode must rtrim consumer trailing newline before diffing so empty provider lines are detected.',
         );
     }
 
@@ -160,10 +267,10 @@ final class AppendModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
-        file_put_contents($projectDir . '/output.txt', 'existing');
+        mkdir($projectDir, 0o777, recursive: true);
+        file_put_contents($projectDir . '/output.txt', "alpha\n");
 
-        $this->makeSourceFile('extra');
+        $this->makeSourceFile("alpha\nbeta\n");
 
         $capturedFlag = null;
 
@@ -172,7 +279,7 @@ final class AppendModeTest extends TestCase
             'file_put_contents',
             [
                 $projectDir . DIRECTORY_SEPARATOR . 'output.txt',
-                'extra',
+                "beta\n",
                 FILE_APPEND,
                 null,
             ],
@@ -193,7 +300,7 @@ final class AppendModeTest extends TestCase
         self::assertSame(
             FILE_APPEND,
             $capturedFlag,
-            'AppendMode must pass FILE_APPEND when the destination already exists.',
+            'AppendMode must pass FILE_APPEND when appending missing lines to an existing destination.',
         );
     }
 

--- a/tests/unit/Scaffold/Modes/PrependModeTest.php
+++ b/tests/unit/Scaffold/Modes/PrependModeTest.php
@@ -66,7 +66,7 @@ final class PrependModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'EXISTING');
 
         $this->makeSourceFile('PREPENDED');
@@ -100,7 +100,7 @@ final class PrependModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'existing');
 
         $this->makeSourceFile('prepended ');
@@ -142,7 +142,7 @@ final class PrependModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents("{$projectDir}/output.txt", 'existing');
 
         $sourcePath = "{$this->tempDir}/provider/stubs/source.txt";

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -46,7 +46,7 @@ final class PreserveModeTest extends TestCase
 
     public function testLockHashIsIgnored(): void
     {
-        // preserveMode never overwrites the lock hash is irrelevant.
+        // 'PreserveMode' never overwrites the lock hash is irrelevant.
         $projectDir = "{$this->tempDir}/project";
 
         mkdir($projectDir, 0o777, recursive: true);
@@ -121,7 +121,7 @@ final class PreserveModeTest extends TestCase
             $result->outcome,
             'PreserveMode must skip the file when it already exists.',
         );
-        // existing file must not be modified.
+        // Existing file must not be modified.
         self::assertSame(
             'user content',
             file_get_contents($projectDir . '/output.txt'),

--- a/tests/unit/Scaffold/Modes/PreserveModeTest.php
+++ b/tests/unit/Scaffold/Modes/PreserveModeTest.php
@@ -49,7 +49,7 @@ final class PreserveModeTest extends TestCase
         // preserveMode never overwrites the lock hash is irrelevant.
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
         $this->makeSourceFile('different stub');
@@ -77,7 +77,7 @@ final class PreserveModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
         $this->makeSourceFile();
@@ -104,7 +104,7 @@ final class PreserveModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'user content');
 
         $this->makeSourceFile('stub content');
@@ -143,9 +143,9 @@ final class PreserveModeTest extends TestCase
 
         $this->makeSourceFile('#!/bin/sh');
 
-        chmod($source, 0755);
+        chmod($source, 0o755);
 
-        $oldUmask = umask(0022);
+        $oldUmask = umask(0o022);
 
         try {
             (new PreserveMode())->apply(
@@ -156,8 +156,8 @@ final class PreserveModeTest extends TestCase
             );
 
             self::assertSame(
-                0755,
-                fileperms("{$this->tempDir}/project/output.txt") & 0777,
+                0o755,
+                fileperms("{$this->tempDir}/project/output.txt") & 0o777,
                 "After 'PreserveMode::apply' copies the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -48,7 +48,7 @@ final class ReplaceModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'original scaffold content');
 
         $this->makeSourceFile('updated stub content');
@@ -101,7 +101,7 @@ final class ReplaceModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'original scaffold content');
 
         $this->makeSourceFile('updated stub content');
@@ -155,9 +155,9 @@ final class ReplaceModeTest extends TestCase
 
         $this->makeSourceFile('#!/bin/sh');
 
-        chmod($source, 0755);
+        chmod($source, 0o755);
 
-        $oldUmask = umask(0022);
+        $oldUmask = umask(0o022);
 
         try {
             (new ReplaceMode())->apply(
@@ -168,8 +168,8 @@ final class ReplaceModeTest extends TestCase
             );
 
             self::assertSame(
-                0755,
-                fileperms("{$this->tempDir}/project/output.txt") & 0777,
+                0o755,
+                fileperms("{$this->tempDir}/project/output.txt") & 0o777,
                 "After 'ReplaceMode::apply' copies the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {
@@ -230,7 +230,7 @@ final class ReplaceModeTest extends TestCase
     {
         $projectDir = "{$this->tempDir}/project";
 
-        mkdir($projectDir, 0777, recursive: true);
+        mkdir($projectDir, 0o777, recursive: true);
         file_put_contents($projectDir . '/output.txt', 'any existing content');
 
         $this->makeSourceFile('fresh stub');

--- a/tests/unit/Scaffold/Modes/ReplaceModeTest.php
+++ b/tests/unit/Scaffold/Modes/ReplaceModeTest.php
@@ -108,7 +108,7 @@ final class ReplaceModeTest extends TestCase
 
         $hasher = new Hasher();
 
-        // lock hash recorded for original; user then modified the file to different content.
+        // Lock hash recorded for original; user then modified the file to different content.
         $lockHash = 'sha256:' . hash('sha256', 'the-original-hash-that-no-longer-matches');
 
         $result = (new ReplaceMode())->apply(
@@ -137,7 +137,7 @@ final class ReplaceModeTest extends TestCase
             $result->warning,
             'Expected warning to mention the file name when file is skipped.',
         );
-        // file must NOT be overwritten.
+        // File must NOT be overwritten.
         self::assertSame(
             'original scaffold content',
             file_get_contents($projectDir . '/output.txt'),
@@ -239,7 +239,7 @@ final class ReplaceModeTest extends TestCase
             $this->makeMapping(),
             $projectDir,
             new Hasher(),
-            null, // no lock hash treat as untracked, overwrite unconditionally
+            null, // No lock hash treat as untracked, overwrite unconditionally.
         );
 
         self::assertSame(

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -94,8 +94,8 @@ final class PathResolverTest extends TestCase
             static function () use (&$isDirCalls): bool {
                 $isDirCalls++;
 
-                // first call (guard): directory does not exist yet, so attempt mkdir.
-                // second call (recheck after mkdir failure): another process created the directory in between.
+                // First call (guard): directory does not exist yet, so attempt mkdir.
+                // Second call (recheck after mkdir failure): another process created the directory in between.
                 return $isDirCalls >= 2;
             },
         );
@@ -318,7 +318,7 @@ final class PathResolverTest extends TestCase
 
         mkdir($vendor, 0o777, recursive: true);
 
-        // relative path normalized through the same helper the production join uses, minus the leading separator.
+        // Relative path normalized through the same helper the production join uses, minus the leading separator.
         $relativeInVendor = ltrim(PathResolver::source('', 'vendor/pkg/name-missing'), '/\\');
 
         $result = PathResolver::resolveProviderRoot(
@@ -348,7 +348,7 @@ final class PathResolverTest extends TestCase
 
     public function testSourceStripsLeadingSeparatorFromSource(): void
     {
-        // single segment avoids `str_replace('/', DIRECTORY_SEPARATOR, ...)` normalization differences on Windows.
+        // Single segment avoids `str_replace('/', DIRECTORY_SEPARATOR, ...)` normalization differences on Windows.
         self::assertSame(
             '/tmp/provider' . DIRECTORY_SEPARATOR . 'file.txt',
             PathResolver::source('/tmp/provider', '/file.txt'),

--- a/tests/unit/Scaffold/PathResolverTest.php
+++ b/tests/unit/Scaffold/PathResolverTest.php
@@ -46,7 +46,7 @@ final class PathResolverTest extends TestCase
             self::markTestSkipped('POSIX umask-based permissions do not apply to NTFS (Windows always reports 0777).');
         }
 
-        $oldUmask = umask(0022);
+        $oldUmask = umask(0o022);
 
         try {
             $dir = $this->tempDir . '/fresh';
@@ -58,8 +58,8 @@ final class PathResolverTest extends TestCase
                 'Directory must be created if it does not exist.',
             );
             self::assertSame(
-                0755,
-                fileperms($dir) & 0777,
+                0o755,
+                fileperms($dir) & 0o777,
                 "Directory must be created with '0777' mode so umask '0022' yields '0755' effective permissions.",
             );
         } finally {
@@ -71,7 +71,7 @@ final class PathResolverTest extends TestCase
     {
         $dir = "{$this->tempDir}/existing";
 
-        mkdir($dir, 0777, recursive: true);
+        mkdir($dir, 0o777, recursive: true);
 
         PathResolver::ensureDirectory($dir . '/file.txt');
 
@@ -102,7 +102,7 @@ final class PathResolverTest extends TestCase
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold',
             'mkdir',
-            [$dir, 0777, true, null],
+            [$dir, 0o777, true, null],
             false,
         );
         PathResolver::ensureDirectory($dir . '/file.txt');
@@ -127,7 +127,7 @@ final class PathResolverTest extends TestCase
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold',
             'mkdir',
-            [$dir, 0777, true, null],
+            [$dir, 0o777, true, null],
             false,
         );
 
@@ -208,7 +208,7 @@ final class PathResolverTest extends TestCase
     {
         $vendor = $this->tempDir;
 
-        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+        mkdir($vendor . '/pkg/name', 0o777, recursive: true);
 
         $result = PathResolver::resolveProviderRoot(
             $vendor,
@@ -231,7 +231,7 @@ final class PathResolverTest extends TestCase
     {
         $vendor = $this->tempDir . '/vendor';
 
-        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+        mkdir($vendor . '/pkg/name', 0o777, recursive: true);
 
         $absoluteLockPath = realpath($vendor . '/pkg/name');
 
@@ -253,8 +253,8 @@ final class PathResolverTest extends TestCase
         $vendor = "{$this->tempDir}/vendor";
         $sibling = "{$this->tempDir}/vendorsibling";
 
-        mkdir($vendor, 0777, recursive: true);
-        mkdir($sibling, 0777, recursive: true);
+        mkdir($vendor, 0o777, recursive: true);
+        mkdir($sibling, 0o777, recursive: true);
 
         $result = PathResolver::resolveProviderRoot($vendor, 'pkg/name', ['path' => $sibling]);
 
@@ -269,7 +269,7 @@ final class PathResolverTest extends TestCase
         $projectRoot = $this->tempDir;
         $vendor = "{$projectRoot}/vendor";
 
-        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+        mkdir($vendor . '/pkg/name', 0o777, recursive: true);
 
         $result = PathResolver::resolveProviderRoot(
             $vendor,
@@ -293,7 +293,7 @@ final class PathResolverTest extends TestCase
     {
         $vendor = $this->tempDir;
 
-        mkdir($vendor . '/pkg/name', 0777, recursive: true);
+        mkdir($vendor . '/pkg/name', 0o777, recursive: true);
 
         $insidePath = "{$vendor}/pkg/name";
 
@@ -316,7 +316,7 @@ final class PathResolverTest extends TestCase
         $projectRoot = PathResolver::destination($tempDir, 'proj');
         $vendor = PathResolver::destination($projectRoot, 'vendor');
 
-        mkdir($vendor, 0777, recursive: true);
+        mkdir($vendor, 0o777, recursive: true);
 
         // relative path normalized through the same helper the production join uses, minus the leading separator.
         $relativeInVendor = ltrim(PathResolver::source('', 'vendor/pkg/name-missing'), '/\\');
@@ -377,17 +377,17 @@ final class PathResolverTest extends TestCase
         file_put_contents($source, "#!/bin/sh\necho hello\n");
         file_put_contents($destination, "#!/bin/sh\necho hello\n");
 
-        chmod($source, 0755);
-        chmod($destination, 0644);
+        chmod($source, 0o755);
+        chmod($destination, 0o644);
 
-        $oldUmask = umask(0022);
+        $oldUmask = umask(0o022);
 
         try {
             PathResolver::syncPermissions($source, $destination);
 
             self::assertSame(
-                0755,
-                fileperms($destination) & 0777,
+                0o755,
+                fileperms($destination) & 0o777,
                 "Under a permissive '0022' umask, 'syncPermissions()' must preserve the source executable bit.",
             );
         } finally {
@@ -407,17 +407,17 @@ final class PathResolverTest extends TestCase
         file_put_contents($source, "#!/bin/sh\n");
         file_put_contents($destination, "#!/bin/sh\n");
 
-        chmod($source, 0755);
-        chmod($destination, 0600);
+        chmod($source, 0o755);
+        chmod($destination, 0o600);
 
-        $oldUmask = umask(0077);
+        $oldUmask = umask(0o077);
 
         try {
             PathResolver::syncPermissions($source, $destination);
 
             self::assertSame(
-                0700,
-                fileperms($destination) & 0777,
+                0o700,
+                fileperms($destination) & 0o777,
                 "Under a restrictive '0077' umask, 'syncPermissions()' must mask source perms and drop group/other bits.",
             );
         } finally {
@@ -437,18 +437,18 @@ final class PathResolverTest extends TestCase
         file_put_contents($source, "#!/bin/sh\n");
         file_put_contents($destination, "#!/bin/sh\n");
 
-        chmod($source, 0640);
-        chmod($destination, 0600);
+        chmod($source, 0o640);
+        chmod($destination, 0o600);
 
         // '0000' umask isolates the `& 0777` mask from the umask step so `& → |` mutations are directly observable.
-        $oldUmask = umask(0000);
+        $oldUmask = umask(0o000);
 
         try {
             PathResolver::syncPermissions($source, $destination);
 
             self::assertSame(
-                0640,
-                fileperms($destination) & 0777,
+                0o640,
+                fileperms($destination) & 0o777,
                 "Under a permissive '0000' umask, the destination must land on exactly the source permissions (0640).",
             );
         } finally {
@@ -466,13 +466,13 @@ final class PathResolverTest extends TestCase
 
         file_put_contents($destination, "#!/bin/sh\n");
 
-        chmod($destination, 0644);
+        chmod($destination, 0o644);
 
         PathResolver::syncPermissions("{$this->tempDir}/does-not-exist", $destination);
 
         self::assertSame(
-            0644,
-            fileperms($destination) & 0777,
+            0o644,
+            fileperms($destination) & 0o777,
             "When 'fileperms()' returns 'false', 'syncPermissions()' must return early and leave the destination untouched.",
         );
     }

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -39,7 +39,7 @@ final class PathValidatorTest extends TestCase
 
     public function testDestinationAcceptsNonExistentFileInsideExistingSubdirectory(): void
     {
-        // walking to an existing in-root ancestor must NOT trigger an escape detection.
+        // Walking to an existing in-root ancestor must NOT trigger an escape detection.
         $root = "{$this->tempDir}/root";
 
         mkdir($root . '/sub', 0o777, recursive: true);
@@ -53,7 +53,7 @@ final class PathValidatorTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        // colon in a non-leading segment must not be mistaken for a Windows drive letter prefix.
+        // Colon in a non-leading segment must not be mistaken for a Windows drive letter prefix.
         (new PathValidator())->validateDestination('nested/C:file.txt', $this->tempDir);
     }
 
@@ -65,7 +65,7 @@ final class PathValidatorTest extends TestCase
             self::markTestSkipped('Symlink canonicalization on Windows is not equivalent to POSIX.');
         }
 
-        // a symlink whose resolved target is `realRoot` itself must pass when used as an ancestor of a missing leaf.
+        // A symlink whose resolved target is `realRoot` itself must pass when used as an ancestor of a missing leaf.
         $root = "{$this->tempDir}/root";
 
         mkdir($root, 0o777, recursive: true);
@@ -114,7 +114,7 @@ final class PathValidatorTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Destination path escapes the root via symlink');
 
-        // the terminal file does not exist, forcing the validator to walk ancestors.
+        // The terminal file does not exist, forcing the validator to walk ancestors.
         (new PathValidator())->validateDestination('escape/missing/file.txt', $root);
     }
 

--- a/tests/unit/Security/PathValidatorTest.php
+++ b/tests/unit/Security/PathValidatorTest.php
@@ -42,7 +42,7 @@ final class PathValidatorTest extends TestCase
         // walking to an existing in-root ancestor must NOT trigger an escape detection.
         $root = "{$this->tempDir}/root";
 
-        mkdir($root . '/sub', 0777, recursive: true);
+        mkdir($root . '/sub', 0o777, recursive: true);
 
         $this->expectNotToPerformAssertions();
 
@@ -68,7 +68,7 @@ final class PathValidatorTest extends TestCase
         // a symlink whose resolved target is `realRoot` itself must pass when used as an ancestor of a missing leaf.
         $root = "{$this->tempDir}/root";
 
-        mkdir($root, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($root, $root . '/loop');
         $this->expectNotToPerformAssertions();
@@ -90,8 +90,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/root";
         $sibling = "{$this->tempDir}/rootsibling";
 
-        mkdir($root, 0777, recursive: true);
-        mkdir($sibling, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
+        mkdir($sibling, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($sibling, $root . '/link');
 
@@ -107,8 +107,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/root";
         $outside = "{$this->tempDir}/outside";
 
-        mkdir($root, 0777, recursive: true);
-        mkdir($outside, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
+        mkdir($outside, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($outside, $root . '/escape');
         $this->expectException(RuntimeException::class);
@@ -124,8 +124,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/root";
         $outside = "{$this->tempDir}/outside";
 
-        mkdir($root, 0777, recursive: true);
-        mkdir($outside, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
+        mkdir($outside, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($outside, "{$root}/escape");
         $this->expectException(RuntimeException::class);
@@ -140,8 +140,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/root";
         $sibling = "{$this->tempDir}/rootsibling";
 
-        mkdir($root, 0777, recursive: true);
-        mkdir($sibling, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
+        mkdir($sibling, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($sibling, "{$root}/link");
         $this->expectException(RuntimeException::class);
@@ -247,8 +247,8 @@ final class PathValidatorTest extends TestCase
         $root = "{$this->tempDir}/provider";
         $outside = "{$this->tempDir}/outside";
 
-        mkdir($root, 0777, recursive: true);
-        mkdir($outside, 0777, recursive: true);
+        mkdir($root, 0o777, recursive: true);
+        mkdir($outside, 0o777, recursive: true);
 
         $this->createSymlinkOrSkip($outside, "{$root}/escape");
         $this->expectException(RuntimeException::class);

--- a/tests/unit/Services/ReapplyServiceTest.php
+++ b/tests/unit/Services/ReapplyServiceTest.php
@@ -746,13 +746,13 @@ final class ReapplyServiceTest extends TestCase
 
         $stubPath = "{$this->tempDir}/vendor/pkg/name/stubs/yii";
 
-        chmod($stubPath, 0755);
+        chmod($stubPath, 0o755);
 
         $destination = "{$this->tempDir}/yii";
 
-        chmod($destination, 0644);
+        chmod($destination, 0o644);
 
-        $oldUmask = umask(0022);
+        $oldUmask = umask(0o022);
 
         try {
             $out = new BufferedOutputWriter();
@@ -766,8 +766,8 @@ final class ReapplyServiceTest extends TestCase
             );
 
             self::assertSame(
-                0755,
-                fileperms($destination) & 0777,
+                0o755,
+                fileperms($destination) & 0o777,
                 "After 'ReapplyService' rewrites the stub, 'syncPermissions' must propagate the source exec bit (0755).",
             );
         } finally {

--- a/tests/unit/Services/ReapplyServiceTest.php
+++ b/tests/unit/Services/ReapplyServiceTest.php
@@ -347,7 +347,7 @@ final class ReapplyServiceTest extends TestCase
         $this->seedTracked('first.txt', "stub\n", "stub\n");
         $this->seedTracked('second.txt', "stub\n", "stub\n");
 
-        // target the first destination exclusively so the mock does not leak into the second iteration's hash calls.
+        // Target the first destination exclusively so the mock does not leak into the second iteration's hash calls.
         MockerState::addCondition(
             'yii\\scaffold\\Scaffold\\Lock',
             'hash_file',

--- a/tests/unit/Services/StatusServiceTest.php
+++ b/tests/unit/Services/StatusServiceTest.php
@@ -34,14 +34,14 @@ final class StatusServiceTest extends TestCase
             [
                 'providers' => [],
                 'files' => [
-                    // first entry fails validation (path traversal) and must emit 'error' while the loop continues.
+                    // First entry fails validation (path traversal) and must emit 'error' while the loop continues.
                     '../escape.php' => [
                         'hash' => 'sha256:abc',
                         'provider' => 'pkg/name',
                         'source' => 'stubs/escape.php',
                         'mode' => 'replace',
                     ],
-                    // second entry must still be reported after the first hit the error-continue path.
+                    // Second entry must still be reported after the first hit the error-continue path.
                     'valid.txt' => [
                         'hash' => $hash,
                         'provider' => 'pkg/name',
@@ -348,7 +348,7 @@ final class StatusServiceTest extends TestCase
         (new StatusService())->run($this->tempDir, $out);
 
         // colFile=max(4, len('../x')=4)=4, colProvider=max(8,1)=8, colMode=max(4,1)=4, colStatus=max(6, 5)=6
-        // separator width = 4 + 8 + 4 + 6 + 6 = 28 dashes.
+        // Separator width = 4 + 8 + 4 + 6 + 6 = 28 dashes.
         self::assertStringContainsString(
             PHP_EOL . str_repeat('-', 28) . PHP_EOL,
             $out->stdoutBuffer,
@@ -474,7 +474,7 @@ final class StatusServiceTest extends TestCase
         (new StatusService())->run($this->tempDir, $out);
 
         // colFile=max(4,1)=4, colProvider=max(8,1)=8, colMode=max(4,1)=4, colStatus=max(6,6 for 'synced')=6
-        // separator width = 4 + 8 + 4 + 6 + 6 = 28 dashes.
+        // Separator width = 4 + 8 + 4 + 6 + 6 = 28 dashes.
         self::assertStringContainsString(
             PHP_EOL . str_repeat('-', 28) . PHP_EOL,
             $out->stdoutBuffer,


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ✔️                                                              |
