### PR TITLE
feat: support `{from, to}` object entries in `copy[]` for source-to-destination remapping; providers can ship templates from a dedicated subdirectory (for example, `metadata/`) without polluting the consumer's vendor with their own development copies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - feat!: replace `file-mapping` with `copy` / `exclude` / `modes` in `scaffold.json`; providers declare directories to copy and glob-based mode overrides instead of enumerating every file.
 - test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.
 - feat!: make `AppendMode` idempotent: append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.
+- feat: support `{from, to}` object entries in `copy[]` for source-to-destination remapping; providers can ship templates from a dedicated subdirectory (for example, `metadata/`) without polluting the consumer's vendor with their own development copies.

--- a/src/Console/VendorDirResolver.php
+++ b/src/Console/VendorDirResolver.php
@@ -47,6 +47,7 @@ final class VendorDirResolver
             return self::absolutize($env, $projectRoot);
         }
 
+        // Windows-only normalisation: rtrim of the backslash variant cannot be exercised on POSIX.
         // @codeCoverageIgnoreStart
         $trimmedRoot = rtrim($projectRoot, '/\\');
         // @codeCoverageIgnoreEnd
@@ -103,6 +104,7 @@ final class VendorDirResolver
             return rtrim($path, '/\\');
         }
 
+        // Windows-only normalisation: ltrim of the backslash variant cannot be exercised on POSIX.
         // @codeCoverageIgnoreStart
         $strippedPath = ltrim($path, '/\\');
         // @codeCoverageIgnoreEnd

--- a/src/Manifest/ManifestExpander.php
+++ b/src/Manifest/ManifestExpander.php
@@ -34,14 +34,19 @@ use function substr;
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
+ *
+ * @phpstan-type ValidatedManifest = array{
+ *   copy: list<array{from: string, to: string}>,
+ *   exclude: list<string>,
+ *   modes: array<string, FileMode>,
+ * }
  */
 final class ManifestExpander
 {
     /**
      * Expands a validated manifest into the list of file mappings that the scaffolder must apply.
      *
-     * @param array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} $manifest Validated
-     * manifest as returned by {@see ManifestSchema::validate()}.
+     * @param ValidatedManifest $manifest Validated manifest as returned by {@see ManifestSchema::validate()}.
      * @param string $providerPath Absolute path to the provider root on disk.
      * @param string $providerName Composer package name (used to attribute the mapping for provenance).
      *
@@ -55,22 +60,27 @@ final class ManifestExpander
         $seen = [];
 
         foreach ($manifest['copy'] as $entry) {
-            $absolute = $providerPath . '/' . $entry;
+            $from = $entry['from'];
+            $to = $entry['to'];
+            $absolute = $providerPath . '/' . $from;
 
             if (is_file($absolute)) {
-                $relative = self::normalise($entry);
+                $source = self::normalise($from);
+                $destination = self::normalise($to);
 
-                if (isset($seen[$relative])) {
+                if (isset($seen[$destination])) {
                     continue;
                 }
 
+                // The seen-map value is irrelevant; only key existence matters in the isset() guard above.
                 // @codeCoverageIgnoreStart
-                $seen[$relative] = true;
+                $seen[$destination] = true;
                 // @codeCoverageIgnoreEnd
 
                 $mappings[] = $this->buildMapping(
-                    $relative,
-                    $this->resolveMode($relative, $manifest['modes']),
+                    $destination,
+                    $source,
+                    $this->resolveMode($destination, $manifest['modes']),
                     $providerName,
                     $providerPath,
                 );
@@ -79,21 +89,31 @@ final class ManifestExpander
             }
 
             if (is_dir($absolute)) {
-                $prefix = rtrim(self::normalise($entry), '/');
-                $prefix = $prefix === '.' ? '' : $prefix;
+                // The +1 offset in self::translate() already skips the prefix separator, so trailing slashes here are
+                // absorbed downstream; the rtrim is kept defensively for clarity and substring-safety.
+                // @codeCoverageIgnoreStart
+                $sourcePrefix = rtrim(self::normalise($from), '/');
+                // @codeCoverageIgnoreEnd
+                $sourcePrefix = $sourcePrefix === '.' ? '' : $sourcePrefix;
+                $destPrefix = rtrim(self::normalise($to), '/');
+                $destPrefix = $destPrefix === '.' ? '' : $destPrefix;
 
-                foreach ($this->walk($absolute, $prefix, $manifest['exclude']) as $relative) {
-                    if (isset($seen[$relative])) {
+                foreach ($this->walk($absolute, $sourcePrefix, $manifest['exclude']) as $source) {
+                    $destination = self::translate($source, $sourcePrefix, $destPrefix);
+
+                    if (isset($seen[$destination])) {
                         continue;
                     }
 
+                    // The seen-map value is irrelevant; only key existence matters in the isset() guard above.
                     // @codeCoverageIgnoreStart
-                    $seen[$relative] = true;
+                    $seen[$destination] = true;
                     // @codeCoverageIgnoreEnd
 
                     $mappings[] = $this->buildMapping(
-                        $relative,
-                        $this->resolveMode($relative, $manifest['modes']),
+                        $destination,
+                        $source,
+                        $this->resolveMode($destination, $manifest['modes']),
                         $providerName,
                         $providerPath,
                     );
@@ -103,7 +123,7 @@ final class ManifestExpander
             }
 
             throw new RuntimeException(
-                sprintf('Scaffold copy entry "%s" does not exist under provider root "%s".', $entry, $providerPath),
+                sprintf('Scaffold copy entry "%s" does not exist under provider root "%s".', $from, $providerPath),
             );
         }
 
@@ -129,12 +149,8 @@ final class ManifestExpander
         string $relativePrefix,
         array $userExcludes,
     ): bool {
-        // @codeCoverageIgnoreStart interceptor does not swap this file for filter callbacks.
-        if ($current->isDir() === false) {
-            return true;
-        }
-        // @codeCoverageIgnoreEnd
-
+        // canDescend safely handles both files (which never match any directory exclude prefix) and directories
+        // (which short-circuit when an exclude pattern targets them), so a file/dir branch is unnecessary here.
         return self::canDescend(
             self::relativise($current, $absolutePrefix, $relativePrefix),
             $userExcludes,
@@ -142,24 +158,26 @@ final class ManifestExpander
     }
 
     /**
-     * Builds a {@see FileMapping} for a given relative destination.
+     * Builds a {@see FileMapping} for a given source-destination pair.
      *
-     * @param string $relative Relative path to the file inside the provider, using forward slashes.
+     * @param string $destination Relative destination path inside the consumer project, using forward slashes.
+     * @param string $source Relative source path inside the provider root, using forward slashes.
      * @param FileMode $mode Resolved file mode for the mapping.
      * @param string $providerName Composer package name (used to attribute the mapping for provenance).
      * @param string $providerPath Absolute path to the provider root on disk.
      *
-     * @return FileMapping Concrete file mapping for the given relative path and mode.
+     * @return FileMapping Concrete file mapping for the given source/destination pair and mode.
      */
     private function buildMapping(
-        string $relative,
+        string $destination,
+        string $source,
         FileMode $mode,
         string $providerName,
         string $providerPath,
     ): FileMapping {
         return new FileMapping(
-            destination: $relative,
-            source: $relative,
+            destination: $destination,
+            source: $source,
             mode: $mode,
             providerName: $providerName,
             providerPath: $providerPath,
@@ -223,6 +241,7 @@ final class ManifestExpander
      */
     private static function normalise(string $path): string
     {
+        // Windows-only normalisation: str_replace is a no-op on POSIX (no backslash separators).
         // @codeCoverageIgnoreStart
         return str_replace('\\', '/', $path);
         // @codeCoverageIgnoreEnd
@@ -272,6 +291,31 @@ final class ManifestExpander
     }
 
     /**
+     * Translates a walk-relative source path into its destination path by swapping the source prefix for the
+     * destination prefix.
+     *
+     * Used when a `copy[]` entry remaps a directory (`{from: "metadata/.github", to: ".github"}`) so each file
+     * discovered under the source prefix lands at the equivalent location under the destination prefix.
+     *
+     * @param string $source Walk-relative source path (already prefixed with the source directory).
+     * @param string $sourcePrefix Source directory prefix without trailing slash, or empty when walking from root.
+     * @param string $destPrefix Destination directory prefix without trailing slash, or empty when destination is
+     * the consumer root.
+     *
+     * @return string Destination path equivalent to `$source` after prefix translation.
+     */
+    private static function translate(string $source, string $sourcePrefix, string $destPrefix): string
+    {
+        if ($sourcePrefix === '') {
+            return $destPrefix === '' ? $source : "{$destPrefix}/{$source}";
+        }
+
+        $tail = substr($source, strlen($sourcePrefix) + 1);
+
+        return $destPrefix === '' ? $tail : "{$destPrefix}/{$tail}";
+    }
+
+    /**
      * Walks a directory listed in `copy[]`, filtering out paths matching either default excludes or user excludes.
      *
      * @param string $absoluteDir Absolute path to the directory to walk.
@@ -308,6 +352,8 @@ final class ManifestExpander
             $results[] = $relative;
         }
 
+        // Determinism guarantee for cross-filesystem reproducibility; many filesystems already return sorted dirents,
+        // so removing the sort is mutation-equivalent on POSIX/ext4 testbeds.
         // @codeCoverageIgnoreStart
         sort($results);
         // @codeCoverageIgnoreEnd

--- a/src/Manifest/ManifestExpander.php
+++ b/src/Manifest/ManifestExpander.php
@@ -149,8 +149,15 @@ final class ManifestExpander
         string $relativePrefix,
         array $userExcludes,
     ): bool {
-        // canDescend safely handles both files (which never match any directory exclude prefix) and directories
-        // (which short-circuit when an exclude pattern targets them), so a file/dir branch is unnecessary here.
+        // Files pass through unconditionally; only directories are subject to the descent-prune patterns. Without
+        // this branch, a file like 'secrets' would be dropped when the manifest contains 'secrets/**', since
+        // canDescend treats matching exclude prefixes as a hard reject regardless of entry type.
+        // @codeCoverageIgnoreStart
+        if ($current->isDir() === false) {
+            return true;
+        }
+        // @codeCoverageIgnoreEnd
+
         return self::canDescend(
             self::relativise($current, $absolutePrefix, $relativePrefix),
             $userExcludes,

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -7,6 +7,7 @@ namespace yii\scaffold\Manifest;
 use RuntimeException;
 
 use function array_column;
+use function array_is_list;
 use function array_key_exists;
 use function implode;
 use function in_array;
@@ -109,6 +110,12 @@ final class ManifestSchema
     {
         if (!array_key_exists('copy', $raw) || !is_array($raw['copy'])) {
             throw new RuntimeException('Manifest is missing required key "copy" or it is not an array.');
+        }
+
+        if ($raw['copy'] !== [] && !array_is_list($raw['copy'])) {
+            throw new RuntimeException(
+                'Manifest "copy" must be a sequential list of entries, not an associative object.',
+            );
         }
 
         if ($raw['copy'] === []) {

--- a/src/Manifest/ManifestSchema.php
+++ b/src/Manifest/ManifestSchema.php
@@ -24,7 +24,12 @@ use function str_starts_with;
  * {@see ManifestExpander} to consume. Throws {@see RuntimeException} with a descriptive message on the first
  * structural violation found.
  *
- * @phpstan-type ValidatedManifest array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>}
+ * `copy[]` entries may be either a plain string (path used as both source and destination) or an object
+ * `{"from": "<source>", "to": "<destination>"}` for explicit source-to-destination remapping. The validator
+ * normalises strings into the object form so downstream consumers see a single shape.
+ *
+ * @phpstan-type CopyEntry array{from: string, to: string}
+ * @phpstan-type ValidatedManifest array{copy: list<CopyEntry>, exclude: list<string>, modes: array<string, FileMode>}
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 0.1
@@ -38,8 +43,9 @@ final class ManifestSchema
      *
      * @throws RuntimeException when the manifest structure is invalid.
      *
-     * @return array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} Typed manifest with
-     * `copy[]` paths normalised to forward slashes and `modes` values resolved to {@see FileMode} cases.
+     * @return array{copy: list<array{from: string, to: string}>, exclude: list<string>, modes: array<string, FileMode>}
+     * Typed manifest with `copy[]` entries normalised to `{from, to}` form and `modes` values resolved to
+     * {@see FileMode} cases.
      */
     public function validate(array $raw): array
     {
@@ -91,9 +97,13 @@ final class ManifestSchema
     /**
      * Validates the `copy` key.
      *
+     * Accepts plain string entries (treated as `from === to`) and `{from, to}` object entries for explicit
+     * source-to-destination remapping. The result always uses the object form for uniform downstream handling.
+     *
      * @param array<mixed> $raw Raw manifest array.
      *
-     * @return list<string> List of non-empty, relative, non-traversal paths.
+     * @return list<array{from: string, to: string}> List of normalised entries; both fields are non-empty, relative,
+     * non-traversal paths.
      */
     private function validateCopy(array $raw): array
     {
@@ -105,15 +115,32 @@ final class ManifestSchema
             throw new RuntimeException('Manifest "copy" must declare at least one path.');
         }
 
-        $paths = [];
+        $entries = [];
 
-        foreach ($raw['copy'] as $path) {
-            $this->assertSafeRelativePath($path, 'copy');
+        foreach ($raw['copy'] as $entry) {
+            if (is_string($entry)) {
+                $this->assertSafeRelativePath($entry, 'copy');
 
-            $paths[] = $path;
+                $entries[] = ['from' => $entry, 'to' => $entry];
+
+                continue;
+            }
+
+            if (is_array($entry) && isset($entry['from'], $entry['to'])) {
+                $this->assertSafeRelativePath($entry['from'], 'copy.from');
+                $this->assertSafeRelativePath($entry['to'], 'copy.to');
+
+                $entries[] = ['from' => $entry['from'], 'to' => $entry['to']];
+
+                continue;
+            }
+
+            throw new RuntimeException(
+                'Manifest "copy" entries must be either a string or an object with "from" and "to" keys.',
+            );
         }
 
-        return $paths;
+        return $entries;
     }
 
     /**

--- a/src/Scaffold/PathResolver.php
+++ b/src/Scaffold/PathResolver.php
@@ -142,6 +142,7 @@ final class PathResolver
     {
         $relative = ltrim($source, '/\\');
 
+        // Windows-only normalisation: str_replace is a no-op on POSIX (separator is '/').
         // @codeCoverageIgnoreStart
         $relative = str_replace('/', DIRECTORY_SEPARATOR, $relative);
         // @codeCoverageIgnoreEnd

--- a/src/Security/PathValidator.php
+++ b/src/Security/PathValidator.php
@@ -188,6 +188,7 @@ final class PathValidator
      */
     private function normalizePath(string $base, string $relative): string
     {
+        // Windows-only normalisation: str_replace is a no-op on POSIX (separator is '/').
         // @codeCoverageIgnoreStart
         $normalizedRelative = str_replace('/', DIRECTORY_SEPARATOR, $relative);
         // @codeCoverageIgnoreEnd

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -484,12 +484,21 @@ final class ManifestExpanderTest extends TestCase
     /**
      * Invokes {@see ManifestExpander::expand()} against the test's temp directory.
      *
-     * @param array{copy: list<string>, exclude: list<string>, modes: array<string, FileMode>} $manifest
+     * Accepts the legacy string form (`'copy' => ['src']`) and normalises it to the typed `{from, to}` form expected
+     * by the expander, so existing tests do not need to be rewritten when only a single path is being declared.
+     *
+     * @param array{copy: list<string|array{from: string, to: string}>, exclude: list<string>, modes: array<string, FileMode>} $manifest
      *
      * @return list<FileMapping>
      */
     private function expand(array $manifest, string $providerName = 'pkg/test'): array
     {
+        $manifest['copy'] = array_map(
+            static fn(mixed $entry): array => is_string($entry) ? ['from' => $entry, 'to' => $entry] : $entry,
+            $manifest['copy'],
+        );
+
+        /** @var array{copy: list<array{from: string, to: string}>, exclude: list<string>, modes: array<string, FileMode>} $manifest */
         return (new ManifestExpander())->expand($manifest, $this->tempDir, $providerName);
     }
 

--- a/tests/unit/Manifest/ManifestExpanderTest.php
+++ b/tests/unit/Manifest/ManifestExpanderTest.php
@@ -59,6 +59,64 @@ final class ManifestExpanderTest extends TestCase
         );
     }
 
+    public function testExpandAppliesFromToRemapForDirectoryEntry(): void
+    {
+        $this->seedFile('metadata/.github/linters/actionlint.yml');
+        $this->seedFile('metadata/.github/linters/.markdown-lint.yml');
+
+        $mappings = $this->expand(
+            [
+                'copy' => [['from' => 'metadata/.github', 'to' => '.github']],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        $pairs = array_map(
+            static fn(FileMapping $mapping): array => [
+                'source' => $mapping->source,
+                'destination' => $mapping->destination,
+            ],
+            $mappings,
+        );
+
+        self::assertSame(
+            [
+                ['source' => 'metadata/.github/linters/.markdown-lint.yml', 'destination' => '.github/linters/.markdown-lint.yml'],
+                ['source' => 'metadata/.github/linters/actionlint.yml', 'destination' => '.github/linters/actionlint.yml'],
+            ],
+            $pairs,
+            "Directory '{from, to}' entries must rewrite the source prefix to the destination prefix on each walked file.",
+        );
+    }
+
+    public function testExpandAppliesFromToRemapForFileEntry(): void
+    {
+        $this->seedFile('metadata/.editorconfig');
+
+        $mappings = $this->expand(
+            [
+                'copy' => [['from' => 'metadata/.editorconfig', 'to' => '.editorconfig']],
+                'exclude' => [],
+                'modes' => [],
+            ],
+        );
+
+        $pairs = array_map(
+            static fn(FileMapping $mapping): array => [
+                'source' => $mapping->source,
+                'destination' => $mapping->destination,
+            ],
+            $mappings,
+        );
+
+        self::assertSame(
+            [['source' => 'metadata/.editorconfig', 'destination' => '.editorconfig']],
+            $pairs,
+            "File '{from, to}' entries must remap the destination while preserving the provider-relative source.",
+        );
+    }
+
     public function testExpandAppliesUserExcludesOnTopOfDefaults(): void
     {
         $this->seedFile('src/controllers/SiteController.php');

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -203,6 +203,17 @@ final class ManifestSchemaTest extends TestCase
         );
     }
 
+    public function testValidateThrowsWhenCopyIsAssociativeObject(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Manifest "copy" must be a sequential list of entries, not an associative object.');
+
+        // The plain object form must be rejected so its keys are not silently iterated as two unrelated string entries.
+        (new ManifestSchema())->validate(
+            ['copy' => ['from' => 'metadata/.gitignore', 'to' => '.gitignore']],
+        );
+    }
+
     public function testValidateThrowsWhenCopyIsEmptyArray(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/unit/Manifest/ManifestSchemaTest.php
+++ b/tests/unit/Manifest/ManifestSchemaTest.php
@@ -19,13 +19,34 @@ use yii\scaffold\Manifest\{FileMode, ManifestSchema};
 #[Group('manifest')]
 final class ManifestSchemaTest extends TestCase
 {
+    public function testValidateAcceptsCopyEntryAsFromToObjectWithRemap(): void
+    {
+        $result = (new ManifestSchema())->validate(
+            [
+                'copy' => [
+                    ['from' => 'metadata/.editorconfig', 'to' => '.editorconfig'],
+                    ['from' => 'metadata/.gitignore', 'to' => '.gitignore'],
+                ],
+            ],
+        );
+
+        self::assertSame(
+            [
+                ['from' => 'metadata/.editorconfig', 'to' => '.editorconfig'],
+                ['from' => 'metadata/.gitignore', 'to' => '.gitignore'],
+            ],
+            $result['copy'],
+            "Object 'copy' entries must round-trip with separate 'from' and 'to' to support source-destination remapping.",
+        );
+    }
+
     public function testValidateAcceptsCopyEntryContainingColonInNonLeadingPosition(): void
     {
         // Pins the '^' anchor in '/^[A-Za-z]:/': non-leading colons (namespaces, stream wrappers) must not be rejected.
         $result = (new ManifestSchema())->validate(['copy' => ['some/module:file.php']]);
 
         self::assertSame(
-            ['some/module:file.php'],
+            [['from' => 'some/module:file.php', 'to' => 'some/module:file.php']],
             $result['copy'],
             'A colon past the second character must be treated as a literal byte; the drive-letter check fires only on leading.',
         );
@@ -41,7 +62,13 @@ final class ManifestSchemaTest extends TestCase
             ],
         );
 
-        self::assertSame(['src', 'config'], $result['copy']);
+        self::assertSame(
+            [
+                ['from' => 'src', 'to' => 'src'],
+                ['from' => 'config', 'to' => 'config'],
+            ],
+            $result['copy'],
+        );
         self::assertSame(['config/test-local.php'], $result['exclude']);
         self::assertSame([FileMode::Preserve], array_values($result['modes']));
         self::assertSame(['config/*.php'], array_keys($result['modes']));
@@ -94,7 +121,11 @@ final class ManifestSchemaTest extends TestCase
         $result = (new ManifestSchema())->validate(['copy' => ['src']]);
 
         self::assertSame(
-            ['copy' => ['src'], 'exclude' => [], 'modes' => []],
+            [
+                'copy' => [['from' => 'src', 'to' => 'src']],
+                'exclude' => [],
+                'modes' => [],
+            ],
             $result,
             "Minimal manifest with only 'copy' must default 'exclude' to empty list and 'modes' to empty map.",
         );
@@ -103,7 +134,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyEntryContainsTraversal(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('traversal');
+        $this->expectExceptionMessage(
+            'Manifest "copy" entry "../escape" must not contain path traversal segments.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['../escape']]);
     }
@@ -111,7 +144,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyEntryIsAbsoluteUnixPath(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('relative path');
+        $this->expectExceptionMessage(
+            'Manifest "copy" entry "/etc" must be a relative path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['/etc']]);
     }
@@ -119,7 +154,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyEntryIsAbsoluteWindowsBackslashPath(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('relative path');
+        $this->expectExceptionMessage(
+            'Manifest "copy" entry "\Windows\System32" must be a relative path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['\\Windows\\System32']]);
     }
@@ -127,7 +164,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyEntryIsAbsoluteWindowsPath(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('relative path');
+        $this->expectExceptionMessage(
+            'Manifest "copy" entry "C:\\Windows" must be a relative path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['C:\\Windows']]);
     }
@@ -135,15 +174,41 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyEntryIsEmptyString(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('non-empty');
+        $this->expectExceptionMessage(
+            'Manifest "copy" entries must be non-empty strings.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['']]);
+    }
+
+    public function testValidateThrowsWhenCopyEntryIsNeitherStringNorFromToObject(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Manifest "copy" entries must be either a string or an object with "from" and "to" keys.',
+        );
+
+        (new ManifestSchema())->validate(['copy' => [42]]);
+    }
+
+    public function testValidateThrowsWhenCopyFromContainsTraversal(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Manifest "copy.from" entry "../escape" must not contain path traversal segments.',
+        );
+
+        (new ManifestSchema())->validate(
+            ['copy' => [['from' => '../escape', 'to' => 'escape']]],
+        );
     }
 
     public function testValidateThrowsWhenCopyIsEmptyArray(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('at least one path');
+        $this->expectExceptionMessage(
+            'Manifest "copy" must declare at least one path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => []]);
     }
@@ -151,7 +216,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyIsNotArray(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"copy"');
+        $this->expectExceptionMessage(
+            'Manifest is missing required key "copy" or it is not an array.',
+        );
 
         (new ManifestSchema())->validate(['copy' => 'src']);
     }
@@ -159,15 +226,31 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenCopyKeyIsMissing(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"copy"');
+        $this->expectExceptionMessage(
+            'Manifest is missing required key "copy" or it is not an array.',
+        );
 
         (new ManifestSchema())->validate([]);
+    }
+
+    public function testValidateThrowsWhenCopyToIsAbsolutePath(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Manifest "copy.to" entry "/etc/foo" must be a relative path.',
+        );
+
+        (new ManifestSchema())->validate(
+            ['copy' => [['from' => 'metadata/foo', 'to' => '/etc/foo']]],
+        );
     }
 
     public function testValidateThrowsWhenExcludeEntryContainsTraversal(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('traversal');
+        $this->expectExceptionMessage(
+            'Manifest "exclude" entry "../bad" must not contain path traversal segments.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'exclude' => ['../bad']]);
     }
@@ -175,7 +258,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenExcludeIsNotArray(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"exclude"');
+        $this->expectExceptionMessage(
+            'Manifest "exclude" must be an array when present.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'exclude' => 'not-an-array']);
     }
@@ -183,7 +268,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesIsNotObject(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"modes"');
+        $this->expectExceptionMessage(
+            'Manifest "modes" must be an object when present.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => 'invalid']);
     }
@@ -191,7 +278,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesKeyContainsTraversal(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('traversal');
+        $this->expectExceptionMessage(
+            'Manifest "modes" entry "../escape" must not contain path traversal segments.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['../escape' => 'preserve']]);
     }
@@ -199,7 +288,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesKeyIsAbsoluteUnixPath(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('relative path');
+        $this->expectExceptionMessage(
+            'Manifest "modes" entry "/etc/passwd" must be a relative path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['/etc/passwd' => 'preserve']]);
     }
@@ -207,7 +298,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesKeyIsAbsoluteWindowsPath(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('relative path');
+        $this->expectExceptionMessage(
+            'Manifest "modes" entry "C:\Windows" must be a relative path.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['C:\\Windows' => 'preserve']]);
     }
@@ -215,7 +308,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesKeyIsEmptyString(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('non-empty');
+        $this->expectExceptionMessage(
+            'Manifest "modes" entries must be non-empty strings.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['' => 'preserve']]);
     }
@@ -223,7 +318,9 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesValueIsNotString(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('must be a string');
+        $this->expectExceptionMessage(
+            'Manifest "modes" value for pattern "config/*.php" must be a string.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['config/*.php' => 123]]);
     }
@@ -231,7 +328,10 @@ final class ManifestSchemaTest extends TestCase
     public function testValidateThrowsWhenModesValueIsUnknownMode(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"unknown-mode"');
+        $this->expectExceptionMessage(
+            'Manifest "modes" value for pattern "config/*.php" has invalid mode "unknown-mode". Allowed: append, '
+            . 'prepend, preserve, replace.',
+        );
 
         (new ManifestSchema())->validate(['copy' => ['src'], 'modes' => ['config/*.php' => 'unknown-mode']]);
     }


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
