### PR TITLE
feat: support `extra.scaffold.auto` flag so consumers can opt out of post-install/post-update/post-create-project auto-trigger and manage provider templates manually via `vendor/bin/scaffold`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - test: shorten test assertion messages and inline comments; extract inline data providers to `tests/providers/` using `#[DataProviderExternal]`.
 - feat!: make `AppendMode` idempotent: append only stub lines not already present in the destination; repeated runs are a no-op and consumer-specific additions are never removed or duplicated.
 - feat: support `{from, to}` object entries in `copy[]` for source-to-destination remapping; providers can ship templates from a dedicated subdirectory (for example, `metadata/`) without polluting the consumer's vendor with their own development copies.
+- feat: support `extra.scaffold.auto` flag so consumers can opt out of post-install/post-update/post-create-project auto-trigger and manage provider templates manually via `vendor/bin/scaffold`.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [`docs/console.md`](docs/console.md) for the full reference.
 
 ## Documentation
 
-- 📥 [Installation Guide](docs/installation.md)
+- 📚 [Installation Guide](docs/installation.md)
 - ⚙️ [Configuration Reference](docs/configuration.md)
 - 📦 [Creating Providers](docs/providers.md)
 - 🔀 [File Modes](docs/modes.md)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Declare the providers that are permitted to write files into your project:
 
 Run `composer install` to trigger the scaffold process. Commit `scaffold-lock.json` to version control.
 
+To opt out of auto-trigger and manage updates manually via `vendor/bin/scaffold`, set `auto: false` (see
+[Configuration Reference](docs/configuration.md#auto)):
+
+```json
+{
+    "extra": {
+        "scaffold": {
+            "auto": false,
+            "allowed-packages": ["yii2-extensions/app-base"]
+        }
+    }
+}
+```
+
 ## Configuration
 
 Minimal `composer.json` for a project using one scaffold provider:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,38 @@ This allows specialised layers to override base-layer defaults without forking t
 
 If the list is empty or absent the plugin writes a notice and exits without modifying any files.
 
+## auto
+
+**Optional, defaults to `true`.** Controls whether the plugin auto-triggers on Composer script events
+(`post-install-cmd`, `post-update-cmd`, `post-create-project-cmd`).
+
+```json
+{
+    "extra": {
+        "scaffold": {
+            "auto": false,
+            "allowed-packages": ["php-forge/baseline"]
+        }
+    }
+}
+```
+
+When `auto: false`, the plugin remains installed and authorised but does not hook into Composer events.
+The CLI commands at `vendor/bin/scaffold` continue to work, so the consumer can sync provider templates
+on demand:
+
+```bash
+vendor/bin/scaffold reapply --provider=php-forge/baseline
+vendor/bin/scaffold diff <file>
+vendor/bin/scaffold status
+```
+
+Use this when **explicit, opt-in updates** matter more than continuous synchronisation, for example on
+repositories where every change to project standards should be reviewed before being applied.
+
+Only an explicit `false` disables the auto-trigger; missing, `null`, non-boolean, or any other value defaults to
+enabled to avoid silent disable on typo.
+
 ## Full annotated example
 
 ```json

--- a/src/EventSubscriber.php
+++ b/src/EventSubscriber.php
@@ -136,11 +136,35 @@ final class EventSubscriber implements EventSubscriberInterface
             if (is_string($item)) {
                 $allowed[] = $item;
             } else {
-                $io->writeError('[scaffold] Non-string entry in allowed-packages ignored.');
+                $io->writeError(
+                    '[scaffold] Non-string entry in allowed-packages ignored.',
+                );
             }
         }
 
         return $allowed;
+    }
+
+    /**
+     * Reads the consumer's `extra.scaffold.auto` flag.
+     *
+     * Auto-trigger is enabled by default. Only an explicit `false` disables the post-install/post-update/
+     * post-create-project hooks, in which case the consumer must invoke `vendor/bin/scaffold` manually to apply
+     * provider templates. Non-boolean values are treated as enabled to avoid silent disable on typo.
+     *
+     * @param array<mixed> $extra `extra` section from the root package's composer.json.
+     *
+     * @return bool `true` when auto-trigger is enabled, `false` only when explicitly disabled by the consumer.
+     */
+    private function isAutoEnabled(array $extra): bool
+    {
+        $scaffold = $extra['scaffold'] ?? null;
+
+        if (!is_array($scaffold)) {
+            return true;
+        }
+
+        return ($scaffold['auto'] ?? null) !== false;
     }
 
     /**
@@ -154,19 +178,32 @@ final class EventSubscriber implements EventSubscriberInterface
     {
         $composer = $event->getComposer();
         $io = $event->getIO();
+
+        if (!$this->isAutoEnabled($composer->getPackage()->getExtra())) {
+            $io->write(
+                '[scaffold] Auto-scaffold disabled via "extra.scaffold.auto"; run "vendor/bin/scaffold" manually.',
+            );
+
+            return;
+        }
+
         $vendorDirRaw = $composer->getConfig()->get('vendor-dir');
 
         if ($vendorDirRaw === '') {
-            $io->writeError('[scaffold] Unable to resolve vendor-dir from Composer config; aborting scaffold.');
+            $io->writeError(
+                '[scaffold] Unable to resolve vendor-dir from Composer config; aborting scaffold.',
+            );
 
             return;
         }
 
         $vendorDirResolved = realpath($vendorDirRaw);
+
         $vendorDir = $vendorDirResolved !== false ? $vendorDirResolved : $vendorDirRaw;
 
         $projectRootRaw = dirname($composer->getConfig()->getConfigSource()->getName());
         $projectRootResolved = realpath($projectRootRaw);
+
         $projectRoot = $projectRootResolved !== false ? $projectRootResolved : $projectRootRaw;
 
         $allowedPackages = $this->extractAllowedPackages($composer->getPackage()->getExtra(), $io);
@@ -194,7 +231,9 @@ final class EventSubscriber implements EventSubscriberInterface
                 $installPaths,
             );
         } catch (Throwable $e) {
-            $io->writeError(sprintf('[scaffold] Scaffolding aborted: %s', $e->getMessage()));
+            $io->writeError(
+                sprintf('[scaffold] Scaffolding aborted: %s', $e->getMessage()),
+            );
         }
     }
 }

--- a/tests/unit/EventSubscriberTest.php
+++ b/tests/unit/EventSubscriberTest.php
@@ -7,6 +7,7 @@ namespace yii\scaffold\tests\unit;
 use Composer\Composer;
 use Composer\Config;
 use Composer\IO\BufferIO;
+use Composer\Package\RootPackageInterface;
 use Composer\Script\Event as ScriptEvent;
 use Composer\Script\ScriptEvents;
 use PHPUnit\Framework\Attributes\Group;
@@ -100,6 +101,100 @@ final class EventSubscriberTest extends TestCase
             'Unable to resolve vendor-dir',
             $io->getOutput(),
             'An empty vendor-dir must short-circuit the scaffold run with a clear error on stderr.',
+        );
+    }
+
+    public function testRunScaffoldProceedsWhenScaffoldExtraIsNotArray(): void
+    {
+        // 'extra.scaffold' set to a non-array value must default to auto-enabled, so the run proceeds and the
+        // vendor-dir guard fires its error (proving the auto check did not short-circuit).
+        $io = new BufferIO();
+
+        $config = self::createStub(Config::class);
+
+        $config->method('get')->willReturn('');
+
+        $package = self::createStub(RootPackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => 'not-an-array']);
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getConfig')->willReturn($config);
+        $composer->method('getPackage')->willReturn($package);
+
+        (new EventSubscriber())->onPostInstall(
+            new ScriptEvent(ScriptEvents::POST_INSTALL_CMD, $composer, $io, true),
+        );
+
+        self::assertStringContainsString(
+            'Unable to resolve vendor-dir',
+            $io->getOutput(),
+            'Non-array "extra.scaffold" must be treated as auto-enabled and let the run proceed past the auto guard.',
+        );
+    }
+
+    public function testRunScaffoldRespectsAutoFalseFlag(): void
+    {
+        $io = new BufferIO();
+
+        $config = self::createStub(Config::class);
+
+        // Empty 'vendor-dir' would emit the resolve error if reached; the auto guard must fire first.
+        $config->method('get')->willReturn('');
+
+        $package = self::createStub(RootPackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['auto' => false]]);
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getConfig')->willReturn($config);
+        $composer->method('getPackage')->willReturn($package);
+
+        (new EventSubscriber())->onPostInstall(
+            new ScriptEvent(ScriptEvents::POST_INSTALL_CMD, $composer, $io, true),
+        );
+
+        self::assertStringContainsString(
+            'Auto-scaffold disabled',
+            $io->getOutput(),
+            'Explicit "extra.scaffold.auto = false" must short-circuit auto-trigger with a clear notice.',
+        );
+        self::assertStringNotContainsString(
+            'Unable to resolve vendor-dir',
+            $io->getOutput(),
+            'When auto is disabled, the run must return BEFORE the vendor-dir guard.',
+        );
+    }
+
+    public function testRunScaffoldRunsWhenAutoFlagIsExplicitlyTrue(): void
+    {
+        // Explicit 'auto: true' must behave identical to the default and let the run proceed; we assert via the
+        // vendor-dir guard which fires further down the runScaffold pipeline.
+        $io = new BufferIO();
+
+        $config = self::createStub(Config::class);
+
+        $config->method('get')->willReturn('');
+
+        $package = self::createStub(RootPackageInterface::class);
+
+        $package->method('getExtra')->willReturn(['scaffold' => ['auto' => true]]);
+
+        $composer = self::createStub(Composer::class);
+
+        $composer->method('getConfig')->willReturn($config);
+        $composer->method('getPackage')->willReturn($package);
+
+        (new EventSubscriber())->onPostInstall(
+            new ScriptEvent(ScriptEvents::POST_INSTALL_CMD, $composer, $io, true),
+        );
+
+        self::assertStringContainsString(
+            'Unable to resolve vendor-dir',
+            $io->getOutput(),
+            'Explicit "auto: true" must let the run proceed past the auto guard.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)